### PR TITLE
fix: Address CodeRabbit review comments

### DIFF
--- a/apps/web/app/(overlay)/overlay/[id]/page.tsx
+++ b/apps/web/app/(overlay)/overlay/[id]/page.tsx
@@ -228,7 +228,7 @@ export default function OverlayPage({ params }: OverlayPageProps) {
       vtube_mouth_param?: string;
       vtube_expression_map?: string | Record<string, string>;
     }) => {
-      if (data.renderer || data.model_url || data.idle_animation || data.vtube_port) {
+      if (data.renderer || data.model_url || data.idle_animation || data.vtube_port || data.vtube_mouth_param || data.vtube_expression_map) {
         // Parse VTube Studio expression map if it's a string
         let expressionMap: Record<string, string> | undefined;
         if (data.vtube_expression_map) {


### PR DESCRIPTION
## Summary

CodeRabbitからのレビュー指摘に対応しました。

## Changes

### 1. overlay/[id]/page.tsx
- `setAvatarConfig` の条件分岐に `vtube_mouth_param` と `vtube_expression_map` を追加
- これらのフィールドのみが存在する場合でも設定が更新されるように

### 2. VTubeStudioBridge.tsx
- `reconnectTimeoutRef` を追加してreconnectタイマーを追跡
- `mountedRef` を追加してアンマウント後の状態更新を防止
- クリーンアップ時にタイマーをクリアしてメモリリークを防止
- reconnect前にマウント状態を確認

## Test plan

- [ ] VTube Studio接続中にコンポーネントをアンマウントしてもエラーが出ない
- [ ] `vtube_mouth_param` のみの更新でもアバター設定が反映される
- [ ] 再接続タイマーが正しくクリーンアップされる

🤖 Generated with [Claude Code](https://claude.ai/code)