### PR TITLE
fix: デフォルトVRM（Flowchan.vrm）を自動読み込みに対応

### DIFF
--- a/apps/web/components/avatar/AvatarView.tsx
+++ b/apps/web/components/avatar/AvatarView.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState, useCallback } from 'react';
 import dynamic from 'next/dynamic';
+import { DEFAULT_MODEL_URL } from '@/lib/constants';
 
 // Dynamically import VRMRenderer to avoid SSR issues with Three.js
 const VRMRenderer = dynamic(() => import('./VRMRenderer'), {
@@ -102,16 +103,9 @@ export default function AvatarView({
   const renderAvatar = useCallback(() => {
     switch (renderer) {
       case 'vrm':
-        if (!modelUrl) {
-          return (
-            <div className="flex items-center justify-center h-full text-white/50">
-              No VRM model specified
-            </div>
-          );
-        }
         return (
           <VRMRenderer
-            modelUrl={modelUrl}
+            modelUrl={modelUrl || DEFAULT_MODEL_URL}
             animationUrl={animationUrl}
             motionUrl={state.motion}
             expression={state.expression}

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -1,3 +1,3 @@
 // Default assets for the application
-export const DEFAULT_MODEL_URL = '/models/default-avatar.vrm';
+export const DEFAULT_MODEL_URL = '/models/Flowchan.vrm';
 export const DEFAULT_IDLE_ANIMATION = '/animations/idle.fbx';


### PR DESCRIPTION
## Summary / 概要
- VRMファイルが指定されていない場合、デフォルトの`Flowchan.vrm`を自動読み込みするよう修正

## Changes / 変更内容
- `constants.ts`: 存在しない`default-avatar.vrm`から実際のファイル`Flowchan.vrm`にパスを修正
- `AvatarView.tsx`: `modelUrl`が未指定時に`DEFAULT_MODEL_URL`をフォールバックとして使用

## Test plan / テスト計画
- [ ] VRMモデルを指定せずにオーバーレイを開き、Flowchan.vrmが表示されることを確認
- [ ] 別のVRMモデルを指定した場合、そのモデルが優先されることを確認

closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default avatar model for enhanced visual consistency across the platform
  * Avatar view now gracefully handles missing model specifications with built-in fallback support, improving overall reliability and preventing empty display states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->