### PR TITLE
feat: MiniMax LLM プラグインのサポートを追加

### DIFF
--- a/apps/web/components/editor/Canvas.tsx
+++ b/apps/web/components/editor/Canvas.tsx
@@ -795,7 +795,7 @@ function getNodeCategory(type: string): 'input' | 'process' | 'output' | 'contro
 
 function getNodeInputs(type: string, config?: Record<string, unknown>): PortDefinition[] {
   // For LLM nodes with prompt builder, generate dynamic inputs from promptSections
-  if (type === 'openai-llm' && config?.promptSections) {
+  if ((type === 'openai-llm' || type === 'minimax-llm') && config?.promptSections) {
     const sections = config.promptSections as PromptSection[];
     const inputSections = sections.filter(s => s.type === 'input');
     if (inputSections.length > 0) {
@@ -844,6 +844,7 @@ function getNodeInputs(type: string, config?: Record<string, unknown>): PortDefi
     'anthropic-llm': [{ id: 'prompt', label: 'Prompt', type: 'string' }],
     'google-llm': [{ id: 'prompt', label: 'Prompt', type: 'string' }],
     'ollama-llm': [{ id: 'prompt', label: 'Prompt', type: 'string' }],
+    'minimax-llm': [{ id: 'prompt', label: 'Prompt', type: 'string' }],
     // Control
     'switch': [
       { id: 'value', label: 'Value', type: 'any' },
@@ -924,6 +925,7 @@ function getNodeOutputs(type: string): PortDefinition[] {
     'anthropic-llm': [{ id: 'response', label: 'Response', type: 'string' }],
     'google-llm': [{ id: 'response', label: 'Response', type: 'string' }],
     'ollama-llm': [{ id: 'response', label: 'Response', type: 'string' }],
+    'minimax-llm': [{ id: 'response', label: 'Response', type: 'string' }],
     // Control
     'switch': [
       { id: 'true', label: 'True', type: 'any' },

--- a/apps/web/components/panels/NodeSettings.tsx
+++ b/apps/web/components/panels/NodeSettings.tsx
@@ -683,6 +683,13 @@ const LLM_MODEL_OPTIONS: Record<string, { label: string; value: string }[]> = {
     { label: "Gemini 2.5 Pro", value: "gemini-2.5-pro-preview-05-06" },
     { label: "Gemini 2.5 Flash", value: "gemini-2.5-flash-preview-05-20" },
   ],
+  minimax: [
+    { label: "MiniMax-M2.5", value: "MiniMax-M2.5" },
+    { label: "MiniMax-M2.5-highspeed", value: "MiniMax-M2.5-highspeed" },
+    { label: "MiniMax-M2.1", value: "MiniMax-M2.1" },
+    { label: "MiniMax-M2.1-highspeed", value: "MiniMax-M2.1-highspeed" },
+    { label: "MiniMax-M2", value: "MiniMax-M2" },
+  ],
 };
 
 // Simplified node config schemas
@@ -896,6 +903,57 @@ const nodeConfigs: Record<string, { label: string; fields: NodeField[] }> = {
         type: "number",
         label: "Temperature",
         placeholder: "0.7",
+      },
+    ],
+  },
+  "minimax-llm": {
+    label: "MiniMax",
+    fields: [
+      {
+        key: "apiKey",
+        type: "password",
+        label: "API Key",
+        placeholder: "sk-...",
+      },
+      {
+        key: "model",
+        type: "select",
+        label: "Model",
+        options: LLM_MODEL_OPTIONS.minimax,
+      },
+      {
+        key: "systemPrompt",
+        type: "textarea",
+        label: "System Prompt",
+        placeholder: "Enter character settings...",
+      },
+      {
+        key: "promptSections",
+        type: "prompt-builder",
+        label: "Prompt Builder",
+      },
+      {
+        key: "temperature",
+        type: "number",
+        label: "Temperature (0.01-1.0)",
+        placeholder: "1.0",
+      },
+      {
+        key: "maxTokens",
+        type: "number",
+        label: "Max Tokens",
+        placeholder: "1024",
+      },
+      {
+        key: "reasoning",
+        type: "select",
+        label: "Reasoning Effort",
+        options: [
+          { label: "None", value: "none" },
+          { label: "Low", value: "low" },
+          { label: "Medium", value: "medium" },
+          { label: "High", value: "high" },
+        ],
       },
     ],
   },

--- a/plugins/minimax-llm/manifest.json
+++ b/plugins/minimax-llm/manifest.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://aituber-flow.dev/schemas/plugin-manifest.json",
+  "id": "minimax-llm",
+  "name": "MiniMax LLM",
+  "version": "1.0.0",
+  "description": "Generate text using MiniMax M2.5 models. Supports advanced reasoning and high-speed inference.",
+  "author": {
+    "name": "AITuberFlow",
+    "url": "https://github.com/oboroge0/AITuberFlow"
+  },
+  "license": "MIT",
+  "category": "llm",
+  "ui": {
+    "label": "MiniMax",
+    "icon": "Cpu",
+    "color": "#FFD700",
+    "bgColor": "rgba(255, 215, 0, 0.1)",
+    "statusText": "Model: MiniMax-M2.5"
+  },
+  "node": {
+    "inputs": [
+      {
+        "id": "prompt",
+        "type": "string",
+        "description": "The input prompt to send to the model"
+      }
+    ],
+    "outputs": [
+      {
+        "id": "response",
+        "type": "string",
+        "description": "The generated response from the model"
+      }
+    ],
+    "events": {
+      "emits": [
+        "response.generated"
+      ],
+      "listens": []
+    }
+  },
+  "config": {
+    "apiKey": {
+      "type": "password",
+      "label": "API Key",
+      "description": "Your MiniMax API key",
+      "required": true
+    },
+    "model": {
+      "type": "select",
+      "label": "Model",
+      "description": "The MiniMax model to use",
+      "default": "MiniMax-M2.5",
+      "options": [
+        {
+          "label": "MiniMax-M2.5 (Recommended)",
+          "value": "MiniMax-M2.5"
+        },
+        {
+          "label": "MiniMax-M2.5-highspeed",
+          "value": "MiniMax-M2.5-highspeed"
+        },
+        {
+          "label": "MiniMax-M2.1",
+          "value": "MiniMax-M2.1"
+        },
+        {
+          "label": "MiniMax-M2.1-highspeed",
+          "value": "MiniMax-M2.1-highspeed"
+        },
+        {
+          "label": "MiniMax-M2",
+          "value": "MiniMax-M2"
+        }
+      ]
+    },
+    "systemPrompt": {
+      "type": "textarea",
+      "label": "System Prompt",
+      "description": "The system message that sets the AI's behavior",
+      "default": "You are a helpful assistant."
+    },
+    "temperature": {
+      "type": "number",
+      "label": "Temperature",
+      "description": "Controls randomness. Range: (0.0, 1.0]. Recommended: 1.0",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 1.0
+    },
+    "maxTokens": {
+      "type": "number",
+      "label": "Max Tokens",
+      "description": "Maximum number of tokens in the response",
+      "default": 1024,
+      "min": 1,
+      "max": 8192
+    },
+    "reasoning": {
+      "type": "select",
+      "label": "Reasoning Effort",
+      "description": "Enable reasoning for complex tasks (M2.5 series only)",
+      "default": "none",
+      "options": [
+        {
+          "label": "None",
+          "value": "none"
+        },
+        {
+          "label": "Low",
+          "value": "low"
+        },
+        {
+          "label": "Medium",
+          "value": "medium"
+        },
+        {
+          "label": "High",
+          "value": "high"
+        }
+      ],
+      "showWhen": {
+        "field": "model",
+        "operator": "in",
+        "value": [
+          "MiniMax-M2.5",
+          "MiniMax-M2.5-highspeed"
+        ]
+      }
+    }
+  }
+}

--- a/plugins/minimax-llm/node.ts
+++ b/plugins/minimax-llm/node.ts
@@ -1,7 +1,7 @@
 /**
  * MiniMax LLM Node
  *
- * Generates text using MiniMax's M2.5 models.
+ * Generates text using MiniMax M2.5 models.
  * Compatible with OpenAI SDK.
  */
 
@@ -16,7 +16,7 @@ interface PromptSection {
 
 export default class MiniMaxLLMNode extends BaseNode {
   private static readonly DEMO_RESPONSE =
-    "これはデモモードの応答です。実際のLLMを使用するにはAPIキーを設定してください。";
+    "This is demo mode. Set API key to use real LLM.";
 
   private static readonly REASONING_MODELS = new Set([
     "MiniMax-M2.5",
@@ -45,10 +45,7 @@ export default class MiniMaxLLMNode extends BaseNode {
     this.promptSections = config.promptSections ?? null;
 
     if (!this.apiKey) {
-      await context.log(
-        "[デモモード] MiniMax APIキー未設定 - 定型文応答を返します",
-        "warning",
-      );
+      await context.log("[Demo Mode] No API key set", "warning");
     } else {
       this.client = new OpenAI({
         apiKey: this.apiKey,
@@ -91,39 +88,19 @@ export default class MiniMaxLLMNode extends BaseNode {
   }
 
   private stripThinkingContent(content: string): string {
-    // Remove thinking tags and content - using template literal to avoid encoding issues
     const thinkStart = "<think>";
-    const thinkEnd = "</";
+    const thinkEnd = "</think>";
     
-    let result = "";
-    let current = 0;
-    const lowerContent = content.toLowerCase();
-    const thinkStartLower = thinkStart.toLowerCase();
+    let result = content;
     
-    let idx = lowerContent.indexOf(thinkStartLower);
-    while (idx !== -1) {
-      result = result + content.substring(current, idx);
+    while (true) {
+      const startIdx = result.indexOf(thinkStart);
+      if (startIdx === -1) break;
       
-      // Find the closing tag
-      const closingStart = idx + thinkStart.length;
-      const endIdx = lowerContent.indexOf(thinkEnd, closingStart);
+      const endIdx = result.indexOf(thinkEnd, startIdx + thinkStart.length);
+      if (endIdx === -1) break;
       
-      if (endIdx !== -1) {
-        current = endIdx + thinkEnd.length;
-      } else {
-        current = content.length;
-        break;
-      }
-      
-      idx = lowerContent.indexOf(thinkStartLower, current);
-    }
-    
-    if (current < content.length) {
-      result = result + content.substring(current);
-    }
-    
-    if (result === "") {
-      result = content;
+      result = result.substring(0, startIdx) + result.substring(endIdx + thinkEnd.length);
     }
     
     return result.trim();
@@ -134,7 +111,7 @@ export default class MiniMaxLLMNode extends BaseNode {
     context: NodeContext,
   ): Promise<Record<string, any>> {
     if (!this.client) {
-      await context.log("[デモモード] 定型文応答を返します", "info");
+      await context.log("[Demo Mode] Returning demo response", "info");
       return { response: MiniMaxLLMNode.DEMO_RESPONSE };
     }
 
@@ -189,7 +166,7 @@ export default class MiniMaxLLMNode extends BaseNode {
       return { response: result };
     } catch (error: unknown) {
       if (error instanceof OpenAI.APIConnectionError) {
-        const errorMsg = getErrorMessage(ErrorCode.LLM_CONNECTION_FAILED, "ja", {
+        const errorMsg = getErrorMessage(ErrorCode.LLM_CONNECTION_FAILED, "en", {
           provider: "MiniMax",
         });
         await context.log(errorMsg, "error");
@@ -197,7 +174,7 @@ export default class MiniMaxLLMNode extends BaseNode {
       }
 
       if (error instanceof OpenAI.RateLimitError) {
-        const errorMsg = getErrorMessage(ErrorCode.LLM_RATE_LIMIT, "ja", {
+        const errorMsg = getErrorMessage(ErrorCode.LLM_RATE_LIMIT, "en", {
           provider: "MiniMax",
         });
         await context.log(errorMsg, "error");
@@ -205,7 +182,7 @@ export default class MiniMaxLLMNode extends BaseNode {
       }
 
       if (error instanceof OpenAI.APIError) {
-        const errorMsg = getErrorMessage(ErrorCode.LLM_API_ERROR, "ja", {
+        const errorMsg = getErrorMessage(ErrorCode.LLM_API_ERROR, "en", {
           provider: "MiniMax",
           error: error.message,
         });

--- a/plugins/minimax-llm/node.ts
+++ b/plugins/minimax-llm/node.ts
@@ -1,0 +1,225 @@
+/**
+ * MiniMax LLM Node
+ *
+ * Generates text using MiniMax's M2.5 models.
+ * Compatible with OpenAI SDK.
+ */
+
+import { BaseNode, NodeContext, createEvent, ErrorCode, getErrorMessage } from "@aituber-flow/sdk";
+import type { Event } from "@aituber-flow/sdk";
+import OpenAI from "openai";
+
+interface PromptSection {
+  type: "text" | "input";
+  content: string;
+}
+
+export default class MiniMaxLLMNode extends BaseNode {
+  private static readonly DEMO_RESPONSE =
+    "これはデモモードの応答です。実際のLLMを使用するにはAPIキーを設定してください。";
+
+  private static readonly REASONING_MODELS = new Set([
+    "MiniMax-M2.5",
+    "MiniMax-M2.5-highspeed",
+  ]);
+
+  private client: OpenAI | null = null;
+  private apiKey: string = "";
+  private model: string = "MiniMax-M2.5";
+  private systemPrompt: string = "You are a helpful assistant.";
+  private temperature: number = 1.0;
+  private maxTokens: number = 1024;
+  private reasoning: string = "none";
+  private promptSections: PromptSection[] | null = null;
+
+  async setup(config: Record<string, any>, context: NodeContext): Promise<void> {
+    this.apiKey = config.apiKey ?? "";
+    this.model = config.model ?? "MiniMax-M2.5";
+    this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
+    this.temperature = config.temperature ?? 1.0;
+    if (this.temperature <= 0) this.temperature = 0.01;
+    if (this.temperature > 1) this.temperature = 1.0;
+    
+    this.maxTokens = config.maxTokens ?? 1024;
+    this.reasoning = config.reasoning ?? "none";
+    this.promptSections = config.promptSections ?? null;
+
+    if (!this.apiKey) {
+      await context.log(
+        "[デモモード] MiniMax APIキー未設定 - 定型文応答を返します",
+        "warning",
+      );
+    } else {
+      this.client = new OpenAI({
+        apiKey: this.apiKey,
+        baseURL: "https://api.minimax.io/v1",
+      });
+      
+      let modelInfo = "model: " + this.model;
+      if (MiniMaxLLMNode.REASONING_MODELS.has(this.model) && this.reasoning !== "none") {
+        modelInfo = modelInfo + ", reasoning: " + this.reasoning;
+      }
+      await context.log("MiniMax client initialized (" + modelInfo + ")");
+    }
+  }
+
+  private buildPromptFromSections(inputs: Record<string, any>): string {
+    if (!this.promptSections) {
+      return (inputs.prompt as string) ?? "";
+    }
+
+    const parts: string[] = [];
+    for (const section of this.promptSections) {
+      if (section.type === "text") {
+        parts.push(section.content);
+      } else if (section.type === "input") {
+        let inputValue: any = inputs[section.content] ?? "";
+        if (typeof inputValue === "object" && inputValue !== null && !Array.isArray(inputValue)) {
+          if ("message" in inputValue) {
+            inputValue = inputValue.message;
+          } else if ("text" in inputValue) {
+            inputValue = inputValue.text;
+          } else {
+            inputValue = String(inputValue);
+          }
+        }
+        parts.push(inputValue ? String(inputValue) : "");
+      }
+    }
+
+    return parts.join("\n");
+  }
+
+  private stripThinkingContent(content: string): string {
+    // Remove thinking tags and content - using template literal to avoid encoding issues
+    const thinkStart = "<think>";
+    const thinkEnd = "</";
+    
+    let result = "";
+    let current = 0;
+    const lowerContent = content.toLowerCase();
+    const thinkStartLower = thinkStart.toLowerCase();
+    
+    let idx = lowerContent.indexOf(thinkStartLower);
+    while (idx !== -1) {
+      result = result + content.substring(current, idx);
+      
+      // Find the closing tag
+      const closingStart = idx + thinkStart.length;
+      const endIdx = lowerContent.indexOf(thinkEnd, closingStart);
+      
+      if (endIdx !== -1) {
+        current = endIdx + thinkEnd.length;
+      } else {
+        current = content.length;
+        break;
+      }
+      
+      idx = lowerContent.indexOf(thinkStartLower, current);
+    }
+    
+    if (current < content.length) {
+      result = result + content.substring(current);
+    }
+    
+    if (result === "") {
+      result = content;
+    }
+    
+    return result.trim();
+  }
+
+  async execute(
+    inputs: Record<string, any>,
+    context: NodeContext,
+  ): Promise<Record<string, any>> {
+    if (!this.client) {
+      await context.log("[デモモード] 定型文応答を返します", "info");
+      return { response: MiniMaxLLMNode.DEMO_RESPONSE };
+    }
+
+    const prompt = this.promptSections
+      ? this.buildPromptFromSections(inputs)
+      : ((inputs.prompt as string) ?? "");
+
+    if (!prompt) {
+      await context.log("No prompt provided", "warning");
+      return { response: "" };
+    }
+
+    try {
+      await context.log("Calling MiniMax API (" + this.model + ")...");
+
+      const characterName = context.getCharacterName();
+      const characterPersonality = context.getCharacterPersonality();
+
+      let fullSystemPrompt = this.systemPrompt;
+      if (characterPersonality) {
+        fullSystemPrompt = this.systemPrompt + "\n\nYou are " + characterName + ". " + characterPersonality;
+      }
+
+      const apiParams: OpenAI.ChatCompletionCreateParamsNonStreaming = {
+        model: this.model,
+        messages: [
+          { role: "system" as const, content: fullSystemPrompt },
+          { role: "user" as const, content: prompt },
+        ],
+        temperature: this.temperature,
+        max_tokens: this.maxTokens,
+      };
+
+      if (MiniMaxLLMNode.REASONING_MODELS.has(this.model) && this.reasoning !== "none") {
+        (apiParams as any).reasoning_effort = this.reasoning;
+      }
+
+      const response = await this.client.chat.completions.create(apiParams);
+
+      let result = response.choices[0].message.content ?? "";
+      result = this.stripThinkingContent(result);
+      
+      await context.log("Response received (" + result.length + " chars)");
+
+      await context.emitEvent(
+        createEvent("response.generated", {
+          text: result,
+          model: this.model,
+        }),
+      );
+
+      return { response: result };
+    } catch (error: unknown) {
+      if (error instanceof OpenAI.APIConnectionError) {
+        const errorMsg = getErrorMessage(ErrorCode.LLM_CONNECTION_FAILED, "ja", {
+          provider: "MiniMax",
+        });
+        await context.log(errorMsg, "error");
+        return { response: "Error: Connection failed" };
+      }
+
+      if (error instanceof OpenAI.RateLimitError) {
+        const errorMsg = getErrorMessage(ErrorCode.LLM_RATE_LIMIT, "ja", {
+          provider: "MiniMax",
+        });
+        await context.log(errorMsg, "error");
+        return { response: "Error: Rate limit exceeded" };
+      }
+
+      if (error instanceof OpenAI.APIError) {
+        const errorMsg = getErrorMessage(ErrorCode.LLM_API_ERROR, "ja", {
+          provider: "MiniMax",
+          error: error.message,
+        });
+        await context.log(errorMsg, "error");
+        return { response: "Error: " + error.message };
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      await context.log("Unexpected error: " + message, "error");
+      return { response: "Error: " + message };
+    }
+  }
+
+  async teardown(): Promise<void> {
+    this.client = null;
+  }
+}


### PR DESCRIPTION
MiniMaxのLLMをAITuberFlowで使用できるようにするプラグインを追加しました。
      
   - **新規プラグイン追加**: `plugins/minimax-llm/`
     - MiniMax M2.5、M2.5-highspeed、M2.1、M2.1-highspeed、M2モデルに対応
     - OpenAI SDK互換のAPIを使用
     - 推論機能サポート
     - 回答からthinkingタグを除去
   - **フロントエンド設定**: NodeSettingsにMiniMax設定UIを追加
   - **入出力ポート**: Canvasにminimax-llmポートを追加
   


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MiniMax LLM support to the workflow editor with multiple M2.5 model options.
  * New MiniMax node type: configurable API key, model, system prompt, temperature, max tokens, reasoning mode, and demo mode fallback.
  * Supports dynamic and static prompt ports plus prompt-section-driven prompt assembly for flexible prompts.
  * Responses are cleaned of internal "thinking" content and emit response events; includes improved error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->