### PR TITLE
feat: ノード検索でconfig値も検索対象にする

### DIFF
--- a/apps/web/components/editor/Canvas.tsx
+++ b/apps/web/components/editor/Canvas.tsx
@@ -187,9 +187,9 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
           if (String(value).toLowerCase().includes(query)) return true;
         } else if (Array.isArray(value)) {
           for (const item of value) {
-            if (typeof item === 'string') {
-              if (item.toLowerCase().includes(query)) return true;
-            } else if (item && typeof item === 'object') {
+            if (typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean') {
+              if (String(item).toLowerCase().includes(query)) return true;
+            } else if (item !== null && typeof item === 'object') {
               if (configMatchesQuery(item as Record<string, unknown>, query)) return true;
             }
           }

--- a/apps/web/components/editor/Canvas.tsx
+++ b/apps/web/components/editor/Canvas.tsx
@@ -176,6 +176,32 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
 
   // Reachable nodes are now computed in the Zustand store (workflowStore)
 
+  // Check if any string value in a config object matches the search query
+  const configMatchesQuery = useCallback(
+    (config: Record<string, unknown> | undefined, query: string): boolean => {
+      if (!config) return false;
+      for (const value of Object.values(config)) {
+        if (typeof value === 'string') {
+          if (value.toLowerCase().includes(query)) return true;
+        } else if (typeof value === 'number' || typeof value === 'boolean') {
+          if (String(value).toLowerCase().includes(query)) return true;
+        } else if (Array.isArray(value)) {
+          for (const item of value) {
+            if (typeof item === 'string') {
+              if (item.toLowerCase().includes(query)) return true;
+            } else if (item && typeof item === 'object') {
+              if (configMatchesQuery(item as Record<string, unknown>, query)) return true;
+            }
+          }
+        } else if (value && typeof value === 'object') {
+          if (configMatchesQuery(value as Record<string, unknown>, query)) return true;
+        }
+      }
+      return false;
+    },
+    []
+  );
+
   // Compute search match node IDs
   const searchMatchIds = useMemo(() => {
     if (!searchVisible || !searchQuery.trim()) return new Set<string>();
@@ -184,11 +210,15 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
       workflowNodes
         .filter((node) => {
           const label = getPluginLabel(node.type).toLowerCase();
-          return label.includes(query) || node.type.toLowerCase().includes(query);
+          return (
+            label.includes(query) ||
+            node.type.toLowerCase().includes(query) ||
+            configMatchesQuery(node.config, query)
+          );
         })
         .map((node) => node.id)
     );
-  }, [searchVisible, searchQuery, workflowNodes, getPluginLabel]);
+  }, [searchVisible, searchQuery, workflowNodes, getPluginLabel, configMatchesQuery]);
 
   // Convert workflow nodes to React Flow nodes
   const flowNodes: Node[] = useMemo(


### PR DESCRIPTION
## 概要
ノード検索（Ctrl+F）で、ノードのラベルやタイプだけでなく、config値（モデル名、APIエンドポイント等）も検索対象に追加しました。

- `configMatchesQuery` ヘルパー関数を追加し、config内の文字列・数値・真偽値を再帰的に検索
- ネストされたオブジェクトや配列内の値にも対応
- config が undefined/null の場合も安全に処理
- 既存の大文字小文字を区別しない検索動作を維持

## テスト計画
- [ ] エディタでCtrl+Fを押し、モデル名（例: `gpt-4`）で検索して、該当ノードがハイライトされることを確認
- [ ] APIエンドポイントURL等のconfig値で検索できることを確認
- [ ] ラベル・タイプでの既存検索が引き続き動作することを確認
- [ ] configが未設定のノードでエラーが発生しないことを確認

closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced editor search functionality to include node configuration values in filtering results, providing more comprehensive search matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->