### PR TITLE
refactor: プラグイン間のイベント発火パターンを統一

### DIFF
--- a/plugins/anthropic-llm/manifest.json
+++ b/plugins/anthropic-llm/manifest.json
@@ -33,7 +33,9 @@
       }
     ],
     "events": {
-      "emits": [],
+      "emits": [
+        "response.generated"
+      ],
       "listens": []
     }
   },

--- a/plugins/anthropic-llm/node.ts
+++ b/plugins/anthropic-llm/node.ts
@@ -4,7 +4,7 @@
  * Generates text using Anthropic's Claude models.
  */
 
-import { BaseNode, NodeContext, handleLLMError } from "@aituber-flow/sdk";
+import { BaseNode, NodeContext, createEvent, handleLLMError } from "@aituber-flow/sdk";
 import Anthropic from "@anthropic-ai/sdk";
 
 export default class AnthropicLLMNode extends BaseNode {
@@ -69,6 +69,14 @@ export default class AnthropicLLMNode extends BaseNode {
       const response =
         firstBlock.type === "text" ? firstBlock.text : "";
       await context.log(`Response received (${response.length} chars)`);
+
+      // Emit event for response generated
+      await context.emitEvent(
+        createEvent("response.generated", {
+          text: response,
+          model: this.model,
+        }),
+      );
 
       return { response };
     } catch (error: unknown) {

--- a/plugins/coeiroink-tts/node.ts
+++ b/plugins/coeiroink-tts/node.ts
@@ -93,22 +93,23 @@ export default class CoeiroinkTTSNode extends BaseNode {
     context: NodeContext,
   ): Promise<Record<string, any>> {
     const text = (inputs.text as string) ?? "";
+    const emptyResult = { audio: "", audioUrl: "", filename: "", duration: 0 };
 
     if (!text) {
       await context.log("No text provided", "warning");
-      return { audio: "", filename: "", duration: 0 };
+      return emptyResult;
     }
 
     // Demo mode: skip TTS if connection is unavailable
     if (this.demoMode && !this.connectionAvailable) {
       const preview = text.length > 30 ? text.slice(0, 30) + "..." : text;
       await context.log(`[デモモード] TTS スキップ: ${preview}`, "info");
-      return { audio: "", filename: "", duration: 0 };
+      return emptyResult;
     }
 
     if (!this.speakerUuid) {
       await context.log("Speaker UUID not configured", "error");
-      return { audio: "", filename: "", duration: 0 };
+      return emptyResult;
     }
 
     try {
@@ -131,7 +132,7 @@ export default class CoeiroinkTTSNode extends BaseNode {
       if (!prosodyResponse.ok) {
         const error = await prosodyResponse.text();
         await context.log(`Prosody estimation failed: ${error}`, "error");
-        return { audio: "" };
+        return emptyResult;
       }
 
       const prosody = await prosodyResponse.json();
@@ -157,7 +158,7 @@ export default class CoeiroinkTTSNode extends BaseNode {
       if (!synthResponse.ok) {
         const error = await synthResponse.text();
         await context.log(`Synthesis failed: ${error}`, "error");
-        return { audio: "" };
+        return emptyResult;
       }
 
       // Save audio file
@@ -188,7 +189,7 @@ export default class CoeiroinkTTSNode extends BaseNode {
       return { audio: filepath, audioUrl, filename, duration };
     } catch (e) {
       await context.log(`COEIROINK error: ${String(e)}`, "error");
-      return { audio: "" };
+      return emptyResult;
     }
   }
 

--- a/plugins/coeiroink-tts/node.ts
+++ b/plugins/coeiroink-tts/node.ts
@@ -170,18 +170,22 @@ export default class CoeiroinkTTSNode extends BaseNode {
 
       const duration = getWavDuration(audioData);
 
-      await context.log(`Audio generated: ${filename}`);
+      const audioUrl = `/api/integrations/audio/${filename}`;
+
+      await context.log(`Audio generated: ${duration.toFixed(2)}s`);
 
       // Emit audio event
       await context.emitEvent(
         createEvent("audio.generated", {
+          audio: filepath,
+          audioUrl,
           filename,
-          text,
           duration,
+          text,
         }),
       );
 
-      return { audio: filepath, filename, duration };
+      return { audio: filepath, audioUrl, filename, duration };
     } catch (e) {
       await context.log(`COEIROINK error: ${String(e)}`, "error");
       return { audio: "" };

--- a/plugins/google-llm/manifest.json
+++ b/plugins/google-llm/manifest.json
@@ -33,7 +33,9 @@
       }
     ],
     "events": {
-      "emits": [],
+      "emits": [
+        "response.generated"
+      ],
       "listens": []
     }
   },

--- a/plugins/google-llm/node.ts
+++ b/plugins/google-llm/node.ts
@@ -4,7 +4,7 @@
  * Generates text using Google's Gemini models.
  */
 
-import { BaseNode, NodeContext, handleLLMError } from "@aituber-flow/sdk";
+import { BaseNode, NodeContext, createEvent, handleLLMError } from "@aituber-flow/sdk";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
 export default class GoogleLLMNode extends BaseNode {
@@ -70,6 +70,14 @@ export default class GoogleLLMNode extends BaseNode {
       const response = await model.generateContent(prompt);
       const result = response.response.text();
       await context.log(`Response received (${result.length} chars)`);
+
+      // Emit event for response generated
+      await context.emitEvent(
+        createEvent("response.generated", {
+          text: result,
+          model: this.model,
+        }),
+      );
 
       return { response: result };
     } catch (error: unknown) {

--- a/plugins/ollama-llm/manifest.json
+++ b/plugins/ollama-llm/manifest.json
@@ -33,7 +33,9 @@
       }
     ],
     "events": {
-      "emits": [],
+      "emits": [
+        "response.generated"
+      ],
       "listens": []
     }
   },

--- a/plugins/ollama-llm/node.ts
+++ b/plugins/ollama-llm/node.ts
@@ -4,7 +4,7 @@
  * Generates text using Ollama local LLM server.
  */
 
-import { BaseNode, NodeContext, handleLLMError } from "@aituber-flow/sdk";
+import { BaseNode, NodeContext, createEvent, handleLLMError } from "@aituber-flow/sdk";
 
 interface OllamaGenerateResponse {
   response: string;
@@ -111,6 +111,15 @@ export default class OllamaLLMNode extends BaseNode {
       const data = (await response.json()) as OllamaGenerateResponse;
       const result = data.response ?? "";
       await context.log(`Response received (${result.length} chars)`);
+
+      // Emit event for response generated
+      await context.emitEvent(
+        createEvent("response.generated", {
+          text: result,
+          model: this.model,
+        }),
+      );
+
       return { response: result };
     } catch (error: unknown) {
       const result = await handleLLMError(error, "Ollama", context);

--- a/plugins/sbv2-tts/node.ts
+++ b/plugins/sbv2-tts/node.ts
@@ -94,17 +94,18 @@ export default class SBV2TTSNode extends BaseNode {
     context: NodeContext,
   ): Promise<Record<string, any>> {
     const text = (inputs.text as string) ?? "";
+    const emptyResult = { audio: "", audioUrl: "", filename: "", duration: 0 };
 
     if (!text) {
       await context.log("No text provided", "warning");
-      return { audio: "", filename: "", duration: 0 };
+      return emptyResult;
     }
 
     // Demo mode: skip TTS if connection is unavailable
     if (this.demoMode && !this.connectionAvailable) {
       const preview = text.length > 30 ? text.slice(0, 30) + "..." : text;
       await context.log(`[デモモード] TTS スキップ: ${preview}`, "info");
-      return { audio: "", filename: "", duration: 0 };
+      return emptyResult;
     }
 
     try {
@@ -133,7 +134,7 @@ export default class SBV2TTSNode extends BaseNode {
       if (!response.ok) {
         const error = await response.text();
         await context.log(`Synthesis failed: ${error}`, "error");
-        return { audio: "", filename: "", duration: 0 };
+        return emptyResult;
       }
 
       // Save audio file
@@ -165,10 +166,10 @@ export default class SBV2TTSNode extends BaseNode {
     } catch (e) {
       if (e instanceof Error && (e.name === "AbortError" || e.name === "TimeoutError")) {
         await context.log("Style-Bert-VITS2 request timed out", "error");
-        return { audio: "", filename: "", duration: 0 };
+        return emptyResult;
       }
       await context.log(`Style-Bert-VITS2 error: ${String(e)}`, "error");
-      return { audio: "", filename: "", duration: 0 };
+      return emptyResult;
     }
   }
 

--- a/plugins/sbv2-tts/node.ts
+++ b/plugins/sbv2-tts/node.ts
@@ -146,18 +146,22 @@ export default class SBV2TTSNode extends BaseNode {
 
       const duration = getWavDuration(audioData);
 
-      await context.log(`Audio generated: ${filename}`);
+      const audioUrl = `/api/integrations/audio/${filename}`;
+
+      await context.log(`Audio generated: ${duration.toFixed(2)}s`);
 
       // Emit audio event
       await context.emitEvent(
         createEvent("audio.generated", {
+          audio: filepath,
+          audioUrl,
           filename,
-          text,
           duration,
+          text,
         }),
       );
 
-      return { audio: filepath, filename, duration };
+      return { audio: filepath, audioUrl, filename, duration };
     } catch (e) {
       if (e instanceof Error && (e.name === "AbortError" || e.name === "TimeoutError")) {
         await context.log("Style-Bert-VITS2 request timed out", "error");


### PR DESCRIPTION
## 概要

同じカテゴリのプラグイン間でイベント発火パターンが不統一だった問題を修正します。

### TTSプラグイン
- **COEIROINK**: `audio.generated` イベントのペイロードに `audio`（ファイルパス）と `audioUrl`（APIパス）を追加し、VOICEVOXと統一
- **Style-Bert-VITS2**: 同上、`audio` と `audioUrl` をペイロードに追加
- 両プラグインの `execute()` 戻り値にも `audioUrl` を追加

### LLMプラグイン
- **Anthropic (Claude)**: `response.generated` イベント（`{text, model}` ペイロード）を追加
- **Google (Gemini)**: 同上
- **Ollama**: 同上
- 各プラグインの `manifest.json` の `events.emits` にも `response.generated` を追加

## リファレンス実装
- TTS: `plugins/voicevox-tts/node.ts` のイベントペイロード形式に統一
- LLM: `plugins/openai-llm/node.ts` のイベント発火パターンに統一

## テスト計画
- [ ] 既存テスト（95件）が全てパスすることを確認済み
- [ ] COEIROINK TTS ノードで音声生成時に `audio.generated` イベントが正しいペイロードで発火されること
- [ ] Style-Bert-VITS2 TTS ノードで同上
- [ ] Anthropic LLM ノードで応答生成時に `response.generated` イベントが発火されること
- [ ] Google LLM ノードで同上
- [ ] Ollama LLM ノードで同上

closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM plugins (Anthropic, Google, Ollama) now emit a "response.generated" event, enabling downstream listeners to react to generated responses with text and model information.
  * TTS plugins (Coeiroink, SBV2) enhanced to include audio URL and text in event payloads, providing more complete information for integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->