### PR TITLE
refactor: フロントエンドのエラーハンドリングを統一

### DIFF
--- a/apps/web/app/(editor)/editor/[id]/client-page.tsx
+++ b/apps/web/app/(editor)/editor/[id]/client-page.tsx
@@ -18,6 +18,7 @@ import api from '@/lib/api';
 import { DEFAULT_MODEL_URL } from '@/lib/constants';
 import { resolveWorkflowId } from '@/lib/routeParams';
 import { getApiBaseUrl } from '@/lib/runtimeEndpoints';
+import { getErrorMessage, handleSilentError } from '@/lib/errorHandler';
 
 const API_BASE = getApiBaseUrl();
 
@@ -190,7 +191,7 @@ export default function EditorPage() {
         await tauri.invoke('open_overlay_window', { workflowId });
         return;
       } catch (error) {
-        console.error('Failed to open overlay window via Tauri command:', error);
+        handleSilentError(error, 'Failed to open overlay window via Tauri command');
       }
     }
 
@@ -204,7 +205,7 @@ export default function EditorPage() {
       await navigator.clipboard.writeText(url);
       toast.success('OBS用オーバーレイURLをコピーしました');
     } catch (error) {
-      console.error('Failed to copy overlay url:', error);
+      handleSilentError(error, 'Failed to copy overlay URL');
       toast.error('URLコピーに失敗しました');
     }
   }, [workflowId]);
@@ -495,7 +496,7 @@ export default function EditorPage() {
         // Use window.location.href to force a full page reload
         window.location.href = `/editor/${response.data.id}`;
       } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+        const errorMessage = getErrorMessage(err);
         toast.error(`インポートに失敗: ${errorMessage}`);
         addLog({ level: 'error', message: `Import failed: ${errorMessage}` });
       }

--- a/apps/web/app/(editor)/preview/[id]/client-page.tsx
+++ b/apps/web/app/(editor)/preview/[id]/client-page.tsx
@@ -8,6 +8,7 @@ import { Workflow } from '@/lib/types';
 import { DEFAULT_MODEL_URL } from '@/lib/constants';
 import { resolveWorkflowId } from '@/lib/routeParams';
 import { getApiBaseUrl, getWsBaseUrl } from '@/lib/runtimeEndpoints';
+import { handleError, handleSilentError } from '@/lib/errorHandler';
 
 const WS_URL = getWsBaseUrl();
 const API_BASE = getApiBaseUrl();
@@ -117,7 +118,7 @@ export default function PreviewPage() {
           }
         }
       } catch (error) {
-        console.error('Failed to load workflow:', error);
+        handleSilentError(error, 'Failed to load workflow');
       }
     };
 
@@ -177,7 +178,7 @@ export default function PreviewPage() {
               const audio = new Audio(audioUrl);
               audioRef.current = audio;
               audio.play().catch((err) => {
-                console.error('Failed to play audio:', err);
+                handleSilentError(err, 'Failed to play audio');
               });
             }
             break;
@@ -209,7 +210,7 @@ export default function PreviewPage() {
   // Control handlers
   const handleStart = useCallback(async () => {
     if (!workflow) {
-      console.error('No workflow data loaded');
+      handleError('No workflow data loaded', 'Workflow start');
       return;
     }
     try {
@@ -219,7 +220,7 @@ export default function PreviewPage() {
         character: workflow.character,
       });
     } catch (error) {
-      console.error('Failed to start workflow:', error);
+      handleError(error, 'Failed to start workflow');
     }
   }, [workflowId, workflow]);
 
@@ -227,7 +228,7 @@ export default function PreviewPage() {
     try {
       await api.stopWorkflow(workflowId);
     } catch (error) {
-      console.error('Failed to stop workflow:', error);
+      handleError(error, 'Failed to stop workflow');
     }
   }, [workflowId]);
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -7,6 +7,7 @@ import api, { TemplateSummary, WorkflowExport } from '@/lib/api';
 import { Workflow } from '@/lib/types';
 import { useTranslation } from '@/stores/localeStore';
 import { toast } from '@/stores/toastStore';
+import { getErrorMessage } from '@/lib/errorHandler';
 import UpdateModal from '@/components/ui/UpdateModal';
 import SettingsModal from '@/components/ui/SettingsModal';
 import AnnouncementBanner from '@/components/ui/AnnouncementBanner';
@@ -200,7 +201,7 @@ export default function HomePage() {
           });
           toast.success(`保存しました: ${String(savedPath)}`);
         } catch (invokeError) {
-          setError(invokeError instanceof Error ? invokeError.message : '保存に失敗しました');
+          setError(getErrorMessage(invokeError, '保存に失敗しました'));
         }
         return;
       }
@@ -250,7 +251,7 @@ export default function HomePage() {
         setError(response.error);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Invalid JSON file');
+      setError(getErrorMessage(err, 'Invalid JSON file'));
     }
 
     if (fileInputRef.current) {

--- a/apps/web/components/avatar/VRMRenderer.tsx
+++ b/apps/web/components/avatar/VRMRenderer.tsx
@@ -7,6 +7,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { loadMixamoAnimation } from './loadMixamoAnimation';
 import { DEFAULT_IDLE_ANIMATION } from '@/lib/constants';
+import { getErrorMessage } from '@/lib/errorHandler';
 
 export interface VRMRendererProps {
   modelUrl: string;
@@ -228,7 +229,7 @@ const VRMRenderer = forwardRef<VRMRendererRef, VRMRendererProps>(function VRMRen
       setLoading(false);
     } catch (err) {
       console.error('Error loading VRM:', err);
-      setError(err instanceof Error ? err.message : 'Failed to load VRM');
+      setError(getErrorMessage(err, 'Failed to load VRM'));
       setLoading(false);
     }
   }, []);

--- a/apps/web/components/panels/NodeSettings.tsx
+++ b/apps/web/components/panels/NodeSettings.tsx
@@ -9,6 +9,7 @@ import { manifestConfigToNodeFields, evaluateShowWhen, normalizeOptions } from "
 import { useSettingsStore } from "@/stores/settingsStore";
 import { LLM_MODEL_OPTIONS } from "@/lib/constants";
 import type { NodeField } from "@/lib/types";
+import { handleError, handleSilentError } from "@/lib/errorHandler";
 
 // Prompt section for structured prompt building
 export interface PromptSection {
@@ -1698,7 +1699,7 @@ export default function NodeSettings() {
         setAnimations(response.data.animations);
       }
     } catch (err) {
-      console.error("Failed to fetch animations:", err);
+      handleSilentError(err, "Failed to fetch animations");
     }
   }, []);
 
@@ -1710,7 +1711,7 @@ export default function NodeSettings() {
         setModels(response.data.models);
       }
     } catch (err) {
-      console.error("Failed to fetch models:", err);
+      handleSilentError(err, "Failed to fetch models");
     }
   }, []);
 
@@ -1730,10 +1731,10 @@ export default function NodeSettings() {
           // Refresh the animations list
           fetchAnimations();
         } else if (response.error) {
-          alert(`Upload failed: ${response.error}`);
+          handleError(response.error, "Upload failed");
         }
       } catch (err) {
-        alert("Failed to upload animation file");
+        handleError(err, "Failed to upload animation file");
       } finally {
         setAnimationUploading(false);
       }
@@ -1757,10 +1758,10 @@ export default function NodeSettings() {
           // Refresh the models list
           fetchModels();
         } else if (response.error) {
-          alert(`Upload failed: ${response.error}`);
+          handleError(response.error, "Upload failed");
         }
       } catch (err) {
-        alert("Failed to upload model file");
+        handleError(err, "Failed to upload model file");
       } finally {
         setModelUploading(false);
       }
@@ -1776,10 +1777,10 @@ export default function NodeSettings() {
         if (response.data) {
           return response.data.url;
         } else if (response.error) {
-          alert(`Upload failed: ${response.error}`);
+          handleError(response.error, "Upload failed");
         }
       } catch (err) {
-        alert("Failed to upload image");
+        handleError(err, "Failed to upload image");
       }
       return null;
     },

--- a/apps/web/components/ui/UpdateModal.tsx
+++ b/apps/web/components/ui/UpdateModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback, useEffect } from 'react';
 import { useTranslation } from '@/stores/localeStore';
+import { getErrorMessage } from '@/lib/errorHandler';
 
 type UpdateStatus = 'available' | 'downloading' | 'error';
 
@@ -69,7 +70,7 @@ export default function UpdateModal({ updateInfo, updateObj, onClose }: UpdateMo
       await relaunch();
     } catch (err) {
       setStatus('error');
-      setErrorMessage(err instanceof Error ? err.message : String(err));
+      setErrorMessage(getErrorMessage(err));
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- updateObj is stable (ref from parent)
   }, []);

--- a/apps/web/hooks/useWebSocket.ts
+++ b/apps/web/hooks/useWebSocket.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { useWorkflowStore } from '@/stores/workflowStore';
 import { AvatarState } from '@/components/avatar';
 import { getApiBaseUrl, getWsBaseUrl } from '@/lib/runtimeEndpoints';
+import { getErrorMessage } from '@/lib/errorHandler';
 
 const WS_URL = getWsBaseUrl();
 const API_URL = getApiBaseUrl();
@@ -205,7 +206,7 @@ export function useWebSocket(workflowId: string | null) {
               console.error('Failed to play audio:', err);
               addLog({
                 level: 'warning',
-                message: `Audio playback failed: ${err.message}`,
+                message: `Audio playback failed: ${getErrorMessage(err)}`,
               });
             });
           }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,4 +1,5 @@
 import { Workflow, PluginManifest, ApiResponse } from './types';
+import { getErrorMessage } from './errorHandler';
 
 // Use relative URLs in browser (proxied via Next.js rewrites)
 // Use full URL only for server-side or when explicitly set
@@ -34,7 +35,7 @@ class ApiClient {
       const data = await response.json();
       return { data };
     } catch (error) {
-      return { error: error instanceof Error ? error.message : 'Network error' };
+      return { error: getErrorMessage(error, 'Network error') };
     }
   }
 
@@ -165,7 +166,7 @@ class ApiClient {
       const data = await response.json();
       return { data };
     } catch (error) {
-      return { error: error instanceof Error ? error.message : 'Upload failed' };
+      return { error: getErrorMessage(error, 'Upload failed') };
     }
   }
 
@@ -198,7 +199,7 @@ class ApiClient {
       const data = await response.json();
       return { data };
     } catch (error) {
-      return { error: error instanceof Error ? error.message : 'Upload failed' };
+      return { error: getErrorMessage(error, 'Upload failed') };
     }
   }
 

--- a/apps/web/lib/errorHandler.ts
+++ b/apps/web/lib/errorHandler.ts
@@ -1,0 +1,48 @@
+import { toast } from '@/stores/toastStore';
+
+/**
+ * Extract a human-readable message from an unknown error value.
+ *
+ * Handles Error instances, objects with a `message` property, plain strings,
+ * and anything else by falling back to a default message.
+ */
+export function getErrorMessage(error: unknown, fallback = 'An unexpected error occurred'): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  ) {
+    return (error as { message: string }).message;
+  }
+  return fallback;
+}
+
+/**
+ * Handle an error that should be shown to the user.
+ *
+ * Shows a toast notification and logs to console for debugging.
+ */
+export function handleError(error: unknown, context?: string): void {
+  const message = getErrorMessage(error);
+  const displayMessage = context ? `${context}: ${message}` : message;
+  toast.error(displayMessage);
+  console.error(context ?? 'Error', error);
+}
+
+/**
+ * Handle an error that is only relevant for debugging.
+ *
+ * Logs to console but does not show a toast notification. Use this for
+ * non-critical errors that do not require user attention (e.g. background
+ * data fetches that fail silently, audio playback issues, etc.).
+ */
+export function handleSilentError(error: unknown, context?: string): void {
+  console.error(context ?? 'Error', error);
+}

--- a/apps/web/stores/pluginStore.ts
+++ b/apps/web/stores/pluginStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { PluginManifest, CategoryDefinition, PluginCategory, ConfigField } from '@/lib/types';
 import { getApiBaseUrl } from '@/lib/runtimeEndpoints';
+import { getErrorMessage } from '@/lib/errorHandler';
 
 // Default categories (fallback if API fails)
 const DEFAULT_CATEGORIES: CategoryDefinition[] = [
@@ -70,7 +71,7 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       console.error('Failed to fetch plugins:', error);
       set({
         isLoading: false,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        error: getErrorMessage(error, 'Failed to fetch plugins'),
       });
     }
   },

--- a/apps/web/stores/settingsStore.ts
+++ b/apps/web/stores/settingsStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import api from '@/lib/api';
+import { getErrorMessage } from '@/lib/errorHandler';
 
 interface SettingsStore {
   settings: Record<string, string>;
@@ -24,7 +25,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         set({ loaded: true, error: res.error || 'Failed to fetch settings' });
       }
     } catch (e) {
-      set({ loaded: true, error: e instanceof Error ? e.message : 'Failed to fetch settings' });
+      set({ loaded: true, error: getErrorMessage(e, 'Failed to fetch settings') });
     }
   },
 


### PR DESCRIPTION
## 概要

フロントエンドのエラーハンドリングパターンを統一しました。

- `apps/web/lib/errorHandler.ts` に統一的なエラーハンドリングユーティリティを追加
  - `getErrorMessage()`: unknown型のエラーから安全にメッセージを抽出
  - `handleError()`: ユーザー向けtoast通知 + consoleログ
  - `handleSilentError()`: consoleログのみ（バックグラウンド処理向け）
- `alert()` を全て `toast.error()` に置き換え（NodeSettings.tsx のアップロードエラー6箇所）
- `err instanceof Error ? err.message : fallback` パターンを `getErrorMessage()` に統一（10ファイル）
- プレビューページのワークフロー開始/停止エラーにユーザー向けtoast通知を追加

## 変更対象ファイル

- `apps/web/lib/errorHandler.ts` (新規)
- `apps/web/lib/api.ts`
- `apps/web/app/page.tsx`
- `apps/web/app/(editor)/editor/[id]/client-page.tsx`
- `apps/web/app/(editor)/preview/[id]/client-page.tsx`
- `apps/web/components/panels/NodeSettings.tsx`
- `apps/web/components/avatar/VRMRenderer.tsx`
- `apps/web/components/ui/UpdateModal.tsx`
- `apps/web/hooks/useWebSocket.ts`
- `apps/web/stores/pluginStore.ts`
- `apps/web/stores/settingsStore.ts`

## テスト計画

- [ ] エディタページでワークフローの読み込み・保存・インポート・エクスポートが正常に動作する
- [ ] ノード設定パネルでアニメーション/モデル/画像アップロードが失敗した場合、toast通知が表示される（alert()ではない）
- [ ] プレビューページでワークフロー開始/停止失敗時にtoast通知が表示される
- [ ] ホームページでインポート失敗時にエラーメッセージが表示される
- [ ] lint エラーがないこと（確認済み）

closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)