### PR TITLE
feat: AivisSpeech・OpenAI TTSプラグインを追加

### DIFF
--- a/apps/server-ts/src/engine/executor.ts
+++ b/apps/server-ts/src/engine/executor.ts
@@ -215,6 +215,8 @@ const GLOBAL_SETTINGS_MAP: Record<string, Record<string, string>> = {
   "voicevox-tts": { host: "voicevox.host" },
   "coeiroink-tts": { host: "coeiroink.host" },
   "sbv2-tts": { host: "sbv2.host" },
+  "aivis-tts": { host: "aivis.host" },
+  "openai-tts": { apiKey: "openai.apiKey" },
 };
 
 function loadGlobalSettings(): Record<string, string> {

--- a/apps/web/components/panels/NodeSettings.tsx
+++ b/apps/web/components/panels/NodeSettings.tsx
@@ -628,6 +628,8 @@ const GLOBAL_SETTINGS_MAP: Record<string, Record<string, string>> = {
   "voicevox-tts": { host: "voicevox.host" },
   "coeiroink-tts": { host: "coeiroink.host" },
   "sbv2-tts": { host: "sbv2.host" },
+  "aivis-tts": { host: "aivis.host" },
+  "openai-tts": { apiKey: "openai.apiKey" },
 };
 
 // LLM_MODEL_OPTIONS imported from @/lib/constants
@@ -957,6 +959,63 @@ const nodeConfigs: Record<string, { label: string; fields: NodeField[] }> = {
       },
       { key: "length", type: "number", label: "Speed", placeholder: "1.0" },
       { key: "demoMode", type: "checkbox", label: "Demo Mode" },
+    ],
+  },
+  "aivis-tts": {
+    label: "TTS (AivisSpeech)",
+    fields: [
+      {
+        key: "host",
+        type: "text",
+        label: "AivisSpeech Host",
+        placeholder: "http://localhost:10101",
+      },
+      {
+        key: "speaker",
+        type: "select",
+        label: "Speaker",
+        dynamic: true,
+        options: [],
+      },
+      { key: "speedScale", type: "number", label: "Speed", placeholder: "1.0" },
+      { key: "demoMode", type: "checkbox", label: "Demo Mode" },
+    ],
+  },
+  "openai-tts": {
+    label: "TTS (OpenAI)",
+    fields: [
+      {
+        key: "apiKey",
+        type: "password",
+        label: "API Key",
+        placeholder: "sk-...",
+      },
+      {
+        key: "model",
+        type: "select",
+        label: "Model",
+        options: [
+          { label: "TTS-1 (Standard)", value: "tts-1" },
+          { label: "TTS-1 HD (High Quality)", value: "tts-1-hd" },
+          { label: "GPT-4o Mini TTS", value: "gpt-4o-mini-tts" },
+        ],
+      },
+      {
+        key: "voice",
+        type: "select",
+        label: "Voice",
+        options: [
+          { label: "Alloy", value: "alloy" },
+          { label: "Ash", value: "ash" },
+          { label: "Coral", value: "coral" },
+          { label: "Echo", value: "echo" },
+          { label: "Fable", value: "fable" },
+          { label: "Nova", value: "nova" },
+          { label: "Onyx", value: "onyx" },
+          { label: "Shimmer", value: "shimmer" },
+        ],
+      },
+      { key: "speed", type: "number", label: "Speed", placeholder: "1.0" },
     ],
   },
   "manual-input": {

--- a/apps/web/components/ui/SettingsModal.tsx
+++ b/apps/web/components/ui/SettingsModal.tsx
@@ -336,7 +336,7 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
             </div>
 
             {/* SBV2 */}
-            <div className="p-3 rounded-lg" style={{ background: 'rgba(0,0,0,0.2)' }}>
+            <div className="mb-4 p-3 rounded-lg" style={{ background: 'rgba(0,0,0,0.2)' }}>
               <h4 className="text-xs font-medium text-white/60 mb-2">Style-Bert-VITS2</h4>
               <div>
                 <label className="block text-[11px] text-white/50 mb-1">{t('globalSettings.host')}</label>
@@ -344,6 +344,19 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
                   value={local['sbv2.host'] || ''}
                   onChange={(v) => set('sbv2.host', v)}
                   placeholder="http://localhost:5000"
+                />
+              </div>
+            </div>
+
+            {/* AivisSpeech */}
+            <div className="p-3 rounded-lg" style={{ background: 'rgba(0,0,0,0.2)' }}>
+              <h4 className="text-xs font-medium text-white/60 mb-2">AivisSpeech</h4>
+              <div>
+                <label className="block text-[11px] text-white/50 mb-1">{t('globalSettings.host')}</label>
+                <TextInput
+                  value={local['aivis.host'] || ''}
+                  onChange={(v) => set('aivis.host', v)}
+                  placeholder="http://localhost:10101"
                 />
               </div>
             </div>

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -102,6 +102,8 @@
     "ollama-llm": "LLM node using local Ollama.\n[Usage] Connect prompt input. Set model in config. *Requires Ollama running.",
     "coeiroink-tts": "TTS node using COEIROINK.\n[Usage] Connect text to read. Select speaker in config. *Requires COEIROINK running.",
     "sbv2-tts": "TTS node using Style-Bert-VITS2.\n[Usage] Connect text to read. Select model in config. *Requires API running.",
+    "aivis-tts": "TTS node using AivisSpeech (VOICEVOX-compatible).\n[Usage] Connect text to read. Select speaker in config. *Requires AivisSpeech running.",
+    "openai-tts": "TTS node using OpenAI TTS API.\n[Usage] Connect text to read. Set voice and model in config.",
     "avatar-configuration": "VRM avatar configuration node.\n[Usage] Set model URL and idle animation. Avatar displays on overlay.",
     "emotion-analyzer": "Emotion analysis node.\n[Usage] Connect text to analyze. Outputs emotion and intensity.",
     "motion-trigger": "Manually trigger expressions and motions.\n[Usage] Connect any input to trigger. Set expression/motion in config.",

--- a/apps/web/locales/ja.json
+++ b/apps/web/locales/ja.json
@@ -102,6 +102,8 @@
     "ollama-llm": "ローカルOllamaでテキスト生成するLLMノード。\n【使い方】promptに質問を接続。設定でモデルを指定。※Ollama起動が必要",
     "coeiroink-tts": "COEIROINKでテキストを音声に変換するTTSノード。\n【使い方】textに読み上げテキストを接続。設定で話者を選択。※COEIROINK起動が必要",
     "sbv2-tts": "Style-Bert-VITS2でテキストを音声に変換するTTSノード。\n【使い方】textに読み上げテキストを接続。設定でモデルを選択。※API起動が必要",
+    "aivis-tts": "AivisSpeechでテキストを音声に変換するTTSノード。\n【使い方】textに読み上げテキストを接続。設定で話者を選択。※AivisSpeech起動が必要",
+    "openai-tts": "OpenAI TTSでテキストを音声に変換するTTSノード。\n【使い方】textに読み上げテキストを接続。設定でボイスとモデルを指定。",
     "avatar-configuration": "VRMアバターの設定ノード。\n【使い方】モデルURL、アイドルアニメーションを設定。オーバーレイでアバターが表示。",
     "emotion-analyzer": "テキストから感情を分析するノード。\n【使い方】textに分析するテキストを接続。emotion/intensityが出力。",
     "motion-trigger": "表情やモーションを手動でトリガーするノード。\n【使い方】triggerに任意の入力を接続。設定で表情/モーションを指定。",

--- a/plugins/aivis-tts/manifest.json
+++ b/plugins/aivis-tts/manifest.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://aituber-flow.dev/schemas/plugin-manifest.json",
+  "id": "aivis-tts",
+  "name": "AivisSpeech TTS",
+  "version": "1.0.0",
+  "description": "Convert text to speech using AivisSpeech engine (VOICEVOX-compatible API). Requires AivisSpeech running locally.",
+  "author": {
+    "name": "AITuberFlow",
+    "url": "https://github.com/oboroge0/AITuberFlow"
+  },
+  "license": "MIT",
+  "category": "tts",
+  "ui": {
+    "label": "AivisSpeech",
+    "icon": "Volume2",
+    "color": "#8B5CF6",
+    "bgColor": "rgba(139, 92, 246, 0.1)",
+    "statusText": "Engine: AivisSpeech"
+  },
+  "node": {
+    "inputs": [
+      {
+        "id": "text",
+        "type": "string",
+        "description": "Text to convert to speech"
+      }
+    ],
+    "outputs": [
+      {
+        "id": "audio",
+        "type": "string",
+        "description": "Path to generated audio file"
+      },
+      {
+        "id": "filename",
+        "type": "string",
+        "description": "Generated audio filename"
+      },
+      {
+        "id": "duration",
+        "type": "number",
+        "description": "Audio duration in seconds"
+      }
+    ],
+    "events": {
+      "emits": [
+        "audio.generated",
+        "audio.playing",
+        "audio.finished"
+      ],
+      "listens": []
+    }
+  },
+  "config": {
+    "host": {
+      "type": "string",
+      "label": "AivisSpeech Host",
+      "description": "AivisSpeech engine host URL",
+      "default": "http://localhost:10101"
+    },
+    "speaker": {
+      "type": "select",
+      "label": "Speaker",
+      "description": "AivisSpeech speaker/character",
+      "default": 1,
+      "dynamic": true,
+      "dependsOn": "host"
+    },
+    "speedScale": {
+      "type": "number",
+      "label": "Speed",
+      "description": "Speech speed (0.5-2.0)",
+      "default": 1,
+      "min": 0.5,
+      "max": 2
+    },
+    "pitchScale": {
+      "type": "number",
+      "label": "Pitch",
+      "description": "Voice pitch (-0.15 to 0.15)",
+      "default": 0,
+      "min": -0.15,
+      "max": 0.15
+    },
+    "volumeScale": {
+      "type": "number",
+      "label": "Volume",
+      "description": "Audio volume (0.0-2.0)",
+      "default": 1,
+      "min": 0,
+      "max": 2
+    },
+    "outputDir": {
+      "type": "string",
+      "label": "Output Directory",
+      "description": "Directory to save audio files (optional)",
+      "default": ""
+    },
+    "demoMode": {
+      "type": "boolean",
+      "label": "Demo Mode",
+      "label_ja": "デモモード",
+      "description": "Skip TTS when AivisSpeech is unavailable",
+      "description_ja": "AivisSpeech未接続時にスキップ",
+      "default": false
+    }
+  }
+}

--- a/plugins/aivis-tts/node.ts
+++ b/plugins/aivis-tts/node.ts
@@ -1,0 +1,226 @@
+/**
+ * AivisSpeech TTS Node
+ *
+ * Converts text to speech using AivisSpeech engine (VOICEVOX-compatible API).
+ * Default port: 10101 (vs VOICEVOX's 50021)
+ */
+
+import { join, resolve } from "path";
+import { mkdirSync, existsSync } from "fs";
+import {
+  BaseNode,
+  type NodeContext,
+  createEvent,
+  ErrorCode,
+  getErrorMessage,
+  getWavDuration,
+} from "@aituber-flow/sdk";
+
+const DEFAULT_AUDIO_DIR = resolve(
+  import.meta.dir,
+  "..",
+  "..",
+  "apps",
+  "server-ts",
+  "audio_output",
+);
+const CONNECT_TIMEOUT_MS = 10_000;
+const QUERY_TIMEOUT_MS = 30_000;
+const SYNTH_TIMEOUT_MS = 60_000;
+
+function resolveAudioOutputDir(configOutputDir: unknown): string {
+  if (typeof configOutputDir === "string" && configOutputDir.trim()) {
+    return resolve(configOutputDir.trim());
+  }
+  const envOutputDir = process.env.AUDIO_OUTPUT_DIR;
+  if (envOutputDir && envOutputDir.trim()) {
+    return resolve(envOutputDir.trim());
+  }
+  return DEFAULT_AUDIO_DIR;
+}
+
+interface Speaker {
+  name?: string;
+  styles?: Array<{ id?: number; name?: string }>;
+}
+
+export default class AivisSpeechTTSNode extends BaseNode {
+  private host = "http://localhost:10101";
+  private speaker = 1;
+  private speedScale = 1.0;
+  private pitchScale = 0.0;
+  private volumeScale = 1.0;
+  private outputDir = "";
+  private demoMode = false;
+  private connectionAvailable = true;
+
+  async setup(
+    config: Record<string, any>,
+    context: NodeContext,
+  ): Promise<void> {
+    this.host = (config.host ?? "http://localhost:10101").replace(/\/+$/, "");
+    this.speaker = Number(config.speaker ?? 1);
+    this.speedScale = Number(config.speedScale ?? 1.0);
+    this.pitchScale = Number(config.pitchScale ?? 0.0);
+    this.volumeScale = Number(config.volumeScale ?? 1.0);
+    this.outputDir = resolveAudioOutputDir(config.outputDir);
+    this.demoMode = config.demoMode ?? false;
+
+    if (!existsSync(this.outputDir)) {
+      mkdirSync(this.outputDir, { recursive: true });
+    }
+
+    try {
+      const response = await fetch(`${this.host}/speakers`, {
+        signal: AbortSignal.timeout(CONNECT_TIMEOUT_MS),
+      });
+      if (response.ok) {
+        const speakers: Speaker[] = await response.json();
+        const speakerName = this.getSpeakerName(speakers, this.speaker);
+        await context.log(`AivisSpeech connected (speaker: ${speakerName})`);
+        this.connectionAvailable = true;
+      } else {
+        this.connectionAvailable = false;
+        if (this.demoMode) {
+          await context.log(
+            "[デモモード] AivisSpeech接続テスト失敗 - スキップします",
+            "warning",
+          );
+        } else {
+          await context.log("AivisSpeech connection test failed", "warning");
+        }
+      }
+    } catch {
+      this.connectionAvailable = false;
+      if (this.demoMode) {
+        await context.log(
+          `[デモモード] AivisSpeechに接続できません (${this.host}) - スキップします`,
+          "warning",
+        );
+      } else {
+        const errorMsg = getErrorMessage(ErrorCode.TTS_CONNECTION_FAILED, "ja", {
+          service: "AivisSpeech",
+          host: this.host,
+        });
+        await context.log(errorMsg, "error");
+      }
+    }
+  }
+
+  private getSpeakerName(speakers: Speaker[], speakerId: number): string {
+    for (const speaker of speakers) {
+      for (const style of speaker.styles ?? []) {
+        if (style.id === speakerId) {
+          return `${speaker.name ?? "Unknown"} (${style.name ?? ""})`;
+        }
+      }
+    }
+    return `Speaker ${speakerId}`;
+  }
+
+  async execute(
+    inputs: Record<string, any>,
+    context: NodeContext,
+  ): Promise<Record<string, any>> {
+    const text = (inputs.text as string) ?? "";
+    if (!text) {
+      await context.log("No text provided for TTS", "warning");
+      return { audio: "", audioUrl: "", filename: "", duration: 0 };
+    }
+
+    if (this.demoMode && !this.connectionAvailable) {
+      const preview = text.length > 30 ? text.slice(0, 30) + "..." : text;
+      await context.log(`[デモモード] TTS スキップ: ${preview}`, "info");
+      return { audio: "", audioUrl: "", filename: "", duration: 0 };
+    }
+
+    try {
+      await context.log(`Generating speech: ${text.slice(0, 30)}...`);
+
+      // Step 1: Create audio query (VOICEVOX-compatible)
+      const queryParams = new URLSearchParams({
+        text,
+        speaker: String(this.speaker),
+      });
+      const queryResponse = await fetch(
+        `${this.host}/audio_query?${queryParams}`,
+        {
+          method: "POST",
+          signal: AbortSignal.timeout(QUERY_TIMEOUT_MS),
+        },
+      );
+      if (!queryResponse.ok) {
+        throw new Error(`audio_query failed: ${queryResponse.status}`);
+      }
+      const query = await queryResponse.json();
+
+      query.speedScale = this.speedScale;
+      query.pitchScale = this.pitchScale;
+      query.volumeScale = this.volumeScale;
+
+      // Step 2: Synthesize audio
+      const synthParams = new URLSearchParams({
+        speaker: String(this.speaker),
+      });
+      const synthResponse = await fetch(
+        `${this.host}/synthesis?${synthParams}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(query),
+          signal: AbortSignal.timeout(SYNTH_TIMEOUT_MS),
+        },
+      );
+      if (!synthResponse.ok) {
+        throw new Error(`synthesis failed: ${synthResponse.status}`);
+      }
+
+      const audioData = new Uint8Array(await synthResponse.arrayBuffer());
+      const id = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+      const filename = `aivis_${id}.wav`;
+      const audioPath = join(this.outputDir, filename);
+
+      await Bun.write(audioPath, audioData);
+
+      const duration = getWavDuration(audioData);
+      const audioUrl = `/api/integrations/audio/${filename}`;
+
+      await context.log(`Audio generated: ${duration.toFixed(2)}s`);
+
+      await context.emitEvent(
+        createEvent("audio.generated", {
+          audio: audioPath,
+          audioUrl,
+          filename,
+          duration,
+          text,
+        }),
+      );
+
+      return { audio: audioPath, audioUrl, filename, duration };
+    } catch (e) {
+      if (
+        (e instanceof TypeError &&
+          (e.message.includes("fetch") || e.message.includes("connect"))) ||
+        (e instanceof Error && (e.name === "AbortError" || e.name === "TimeoutError"))
+      ) {
+        const errorMsg = getErrorMessage(
+          ErrorCode.TTS_CONNECTION_FAILED,
+          "ja",
+          { service: "AivisSpeech", host: this.host },
+        );
+        await context.log(errorMsg, "error");
+      } else {
+        const errorMsg = getErrorMessage(
+          ErrorCode.TTS_SYNTHESIS_FAILED,
+          "ja",
+          { service: "AivisSpeech", error: String(e) },
+        );
+        await context.log(errorMsg, "error");
+      }
+      return { audio: "", audioUrl: "", filename: "", duration: 0 };
+    }
+  }
+
+  async teardown(): Promise<void> {}
+}

--- a/plugins/openai-tts/manifest.json
+++ b/plugins/openai-tts/manifest.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://aituber-flow.dev/schemas/plugin-manifest.json",
+  "id": "openai-tts",
+  "name": "OpenAI TTS",
+  "version": "1.0.0",
+  "description": "Convert text to speech using OpenAI TTS API. Supports multiple voices and models including gpt-4o-mini-tts.",
+  "author": {
+    "name": "AITuberFlow",
+    "url": "https://github.com/oboroge0/AITuberFlow"
+  },
+  "license": "MIT",
+  "category": "tts",
+  "ui": {
+    "label": "OpenAI TTS",
+    "icon": "AudioLines",
+    "color": "#10B981",
+    "bgColor": "rgba(16, 185, 129, 0.1)",
+    "statusText": "Engine: OpenAI"
+  },
+  "node": {
+    "inputs": [
+      {
+        "id": "text",
+        "type": "string",
+        "description": "Text to convert to speech"
+      }
+    ],
+    "outputs": [
+      {
+        "id": "audio",
+        "type": "string",
+        "description": "Path to generated audio file"
+      },
+      {
+        "id": "filename",
+        "type": "string",
+        "description": "Generated audio filename"
+      },
+      {
+        "id": "duration",
+        "type": "number",
+        "description": "Audio duration in seconds"
+      }
+    ],
+    "events": {
+      "emits": [
+        "audio.generated",
+        "audio.playing",
+        "audio.finished"
+      ],
+      "listens": []
+    }
+  },
+  "config": {
+    "apiKey": {
+      "type": "password",
+      "label": "API Key",
+      "description": "Your OpenAI API key",
+      "required": true
+    },
+    "model": {
+      "type": "select",
+      "label": "Model",
+      "description": "TTS model to use",
+      "default": "tts-1",
+      "options": [
+        { "label": "TTS-1 (Standard)", "value": "tts-1" },
+        { "label": "TTS-1 HD (High Quality)", "value": "tts-1-hd" },
+        { "label": "GPT-4o Mini TTS", "value": "gpt-4o-mini-tts" }
+      ]
+    },
+    "voice": {
+      "type": "select",
+      "label": "Voice",
+      "description": "Voice to use for speech",
+      "default": "alloy",
+      "options": [
+        { "label": "Alloy", "value": "alloy" },
+        { "label": "Ash", "value": "ash" },
+        { "label": "Ballad", "value": "ballad" },
+        { "label": "Coral", "value": "coral" },
+        { "label": "Echo", "value": "echo" },
+        { "label": "Fable", "value": "fable" },
+        { "label": "Nova", "value": "nova" },
+        { "label": "Onyx", "value": "onyx" },
+        { "label": "Sage", "value": "sage" },
+        { "label": "Shimmer", "value": "shimmer" }
+      ]
+    },
+    "speed": {
+      "type": "number",
+      "label": "Speed",
+      "description": "Speech speed (0.25-4.0)",
+      "default": 1,
+      "min": 0.25,
+      "max": 4
+    },
+    "instructions": {
+      "type": "textarea",
+      "label": "Instructions",
+      "description": "Voice style instructions (gpt-4o-mini-tts only)",
+      "default": "",
+      "showWhen": {
+        "field": "model",
+        "operator": "equals",
+        "value": "gpt-4o-mini-tts"
+      }
+    },
+    "outputDir": {
+      "type": "string",
+      "label": "Output Directory",
+      "description": "Directory to save audio files (optional)",
+      "default": ""
+    }
+  }
+}

--- a/plugins/openai-tts/node.ts
+++ b/plugins/openai-tts/node.ts
@@ -1,0 +1,142 @@
+/**
+ * OpenAI TTS Node
+ *
+ * Converts text to speech using OpenAI's TTS API.
+ * Supports tts-1, tts-1-hd, and gpt-4o-mini-tts models.
+ */
+
+import { join, resolve } from "path";
+import { mkdirSync, existsSync } from "fs";
+import {
+  BaseNode,
+  type NodeContext,
+  createEvent,
+  getWavDuration,
+} from "@aituber-flow/sdk";
+import OpenAI from "openai";
+
+const DEFAULT_AUDIO_DIR = resolve(
+  import.meta.dir,
+  "..",
+  "..",
+  "apps",
+  "server-ts",
+  "audio_output",
+);
+
+function resolveAudioOutputDir(configOutputDir: unknown): string {
+  if (typeof configOutputDir === "string" && configOutputDir.trim()) {
+    return resolve(configOutputDir.trim());
+  }
+  const envOutputDir = process.env.AUDIO_OUTPUT_DIR;
+  if (envOutputDir && envOutputDir.trim()) {
+    return resolve(envOutputDir.trim());
+  }
+  return DEFAULT_AUDIO_DIR;
+}
+
+export default class OpenAITTSNode extends BaseNode {
+  private static readonly DEMO_RESPONSE = "デモモード: APIキー未設定のためTTSをスキップします";
+
+  private client: OpenAI | null = null;
+  private model: string = "tts-1";
+  private voice: string = "alloy";
+  private speed: number = 1.0;
+  private instructions: string = "";
+  private outputDir: string = "";
+
+  async setup(
+    config: Record<string, any>,
+    context: NodeContext,
+  ): Promise<void> {
+    const apiKey = config.apiKey ?? "";
+    this.model = config.model ?? "tts-1";
+    this.voice = config.voice ?? "alloy";
+    this.speed = Number(config.speed ?? 1.0);
+    this.instructions = config.instructions ?? "";
+    this.outputDir = resolveAudioOutputDir(config.outputDir);
+
+    if (!existsSync(this.outputDir)) {
+      mkdirSync(this.outputDir, { recursive: true });
+    }
+
+    if (!apiKey) {
+      await context.log(
+        "[デモモード] OpenAI APIキー未設定 - TTSをスキップします",
+        "warning",
+      );
+    } else {
+      this.client = new OpenAI({ apiKey });
+      await context.log(
+        `OpenAI TTS initialized (model: ${this.model}, voice: ${this.voice})`,
+      );
+    }
+  }
+
+  async execute(
+    inputs: Record<string, any>,
+    context: NodeContext,
+  ): Promise<Record<string, any>> {
+    const text = (inputs.text as string) ?? "";
+    if (!text) {
+      await context.log("No text provided for TTS", "warning");
+      return { audio: "", audioUrl: "", filename: "", duration: 0 };
+    }
+
+    if (!this.client) {
+      await context.log("[デモモード] TTS スキップ", "info");
+      return { audio: "", audioUrl: "", filename: "", duration: 0 };
+    }
+
+    try {
+      await context.log(`Generating speech: ${text.slice(0, 30)}...`);
+
+      const requestBody: Record<string, any> = {
+        model: this.model,
+        voice: this.voice,
+        input: text,
+        speed: this.speed,
+        response_format: "wav",
+      };
+
+      // instructions is only supported by gpt-4o-mini-tts
+      if (this.model === "gpt-4o-mini-tts" && this.instructions) {
+        requestBody.instructions = this.instructions;
+      }
+
+      const response = await this.client.audio.speech.create(requestBody as any);
+
+      const audioData = new Uint8Array(await response.arrayBuffer());
+      const id = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+      const filename = `openai_tts_${id}.wav`;
+      const audioPath = join(this.outputDir, filename);
+
+      await Bun.write(audioPath, audioData);
+
+      const duration = getWavDuration(audioData);
+      const audioUrl = `/api/integrations/audio/${filename}`;
+
+      await context.log(`Audio generated: ${duration.toFixed(2)}s`);
+
+      await context.emitEvent(
+        createEvent("audio.generated", {
+          audio: audioPath,
+          audioUrl,
+          filename,
+          duration,
+          text,
+        }),
+      );
+
+      return { audio: audioPath, audioUrl, filename, duration };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await context.log(`OpenAI TTS error: ${message}`, "error");
+      return { audio: "", audioUrl: "", filename: "", duration: 0 };
+    }
+  }
+
+  async teardown(): Promise<void> {
+    this.client = null;
+  }
+}


### PR DESCRIPTION
## Summary
- AivisSpeech TTSプラグインを新規追加（VOICEVOX互換API、デフォルト: localhost:10101）
- OpenAI TTSプラグインを新規追加（tts-1/tts-1-hd/gpt-4o-mini-ttsモデル、10種類のボイス）
- グローバル設定画面にAivisSpeechホスト設定を追加
- OpenAI TTSはOpenAI APIキーのグローバル設定を共有

## 変更内容
- `plugins/aivis-tts/` — AivisSpeechプラグイン本体
- `plugins/openai-tts/` — OpenAI TTSプラグイン本体
- `apps/server-ts/src/engine/executor.ts` — グローバル設定マッピング追加
- `apps/web/components/ui/SettingsModal.tsx` — 設定画面にAivisSpeechセクション追加
- `apps/web/components/panels/NodeSettings.tsx` — ノード設定パネル対応
- `apps/web/locales/{en,ja}.json` — ローカライズ追加

## Test plan
- [x] `npm test` — 全116テスト通過
- [x] `npm run lint` — 新規エラーなし
- [ ] AivisSpeech TTSノードを追加し、話者選択・音声生成が動作することを確認
- [ ] OpenAI TTSノードを追加し、ボイス選択・音声生成が動作することを確認
- [ ] グローバル設定でAivisSpeechホストを設定し、ノードに反映されることを確認

closes #92 (AivisSpeech・OpenAI TTS部分)

🤖 Generated with [Claude Code](https://claude.com/claude-code)