### PR TITLE
fix: バリデーションでグローバル設定を考慮するように修正

### DIFF
--- a/apps/server-ts/src/engine/validator.ts
+++ b/apps/server-ts/src/engine/validator.ts
@@ -142,12 +142,15 @@ function loadGlobalSettings(): Record<string, string> {
 function checkRequiredConfigCore(
   nodes: NodeData[],
   manifests: Map<string, PluginManifest | null>,
+  settings?: Record<string, string>,
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
   for (const node of nodes) {
     const manifest = manifests.get(node.type);
     if (!manifest?.config) continue;
+
+    const globalMapping = GLOBAL_SETTINGS_MAP[node.type];
 
     for (const [key, fieldDef] of Object.entries(manifest.config)) {
       if (!fieldDef.required) continue;
@@ -157,6 +160,10 @@ function checkRequiredConfigCore(
         value === undefined || value === null || value === "";
 
       if (isEmpty) {
+        // Skip if a global setting provides this value
+        const globalKey = globalMapping?.[key];
+        if (globalKey && settings?.[globalKey]) continue;
+
         issues.push({
           nodeId: node.id,
           nodeName: manifest.name || node.type,
@@ -176,8 +183,9 @@ function checkRequiredConfigCore(
 async function checkRequiredConfig(
   nodes: NodeData[],
   manifests: Map<string, PluginManifest | null>,
+  settings?: Record<string, string>,
 ): Promise<ValidationIssue[]> {
-  return checkRequiredConfigCore(nodes, manifests);
+  return checkRequiredConfigCore(nodes, manifests, settings);
 }
 
 /**
@@ -459,7 +467,7 @@ export async function validateWorkflow(
   const issues: ValidationIssue[] = [];
 
   // 1. Required config fields
-  issues.push(...(await checkRequiredConfig(nodes, manifests)));
+  issues.push(...(await checkRequiredConfig(nodes, manifests, settings)));
 
   // 2. Unconnected required input ports
   issues.push(...checkUnconnectedInputs(nodes, connections, manifests));
@@ -494,7 +502,7 @@ export function validateWorkflowSync(
   const issues: ValidationIssue[] = [];
 
   // 1. Required config fields (using shared core logic)
-  issues.push(...checkRequiredConfigCore(nodes, manifests));
+  issues.push(...checkRequiredConfigCore(nodes, manifests, settings));
 
   // 2. Unconnected required input ports
   issues.push(...checkUnconnectedInputs(nodes, connections, manifests));


### PR DESCRIPTION
## 概要

- `checkRequiredConfigCore` がノード個別のconfigのみをチェックし、グローバル設定（設定画面で入力したAPIキー等）を無視していた
- グローバル設定でAPIキーを設定していてもバリデーションエラーになりワークフローを実行できない問題を修正

## 変更内容

- `checkRequiredConfigCore` に `settings` パラメータを追加
- 必須フィールドが空でも、`GLOBAL_SETTINGS_MAP` に対応するグローバル設定が存在すればエラーをスキップ
- `checkRequiredConfig`, `validateWorkflow`, `validateWorkflowSync` の呼び出し元からも `settings` を渡すように修正

## テスト計画

- [ ] グローバル設定にAPIキーを設定した状態でワークフローを実行できることを確認
- [ ] ノード個別にAPIキーを設定した場合も引き続き動作することを確認
- [ ] APIキーがどちらにも設定されていない場合はバリデーションエラーになることを確認
- [ ] `npm test` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration validation now respects global settings to override required field configuration for individual nodes. When a global setting provides the necessary configuration value, the validation error for a missing required field is no longer raised. This improvement enhances configuration flexibility and is available in both synchronous and asynchronous workflow validation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->