### PR TITLE
fix: セキュリティ監査で発見された脆弱性を修正 (#148)

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -9,7 +9,7 @@
   },
   "app": {
     "security": {
-      "csp": null
+      "csp": "default-src 'self' asset: http://asset.localhost; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost https:; media-src 'self' blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://localhost:* wss://localhost:* ws://127.0.0.1:* wss://127.0.0.1:* http://localhost:* http://127.0.0.1:* https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://api.groq.com https://api.mistral.ai https://www.googleapis.com https://*.youtube.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
     },
     "windows": [
       {

--- a/apps/server-ts/src/engine/executor.ts
+++ b/apps/server-ts/src/engine/executor.ts
@@ -147,7 +147,12 @@ export class NodeContext {
   }
 
   async updateCharacter(updates: Record<string, any>): Promise<void> {
-    Object.assign(this.character, updates);
+    // Guard against prototype pollution: never copy __proto__/constructor/prototype
+    // keys from user-controllable updates into the character state.
+    for (const [key, value] of Object.entries(updates)) {
+      if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+      this.character[key] = value;
+    }
   }
 
   getCharacterName(): string {

--- a/apps/server-ts/src/routes/workflows.ts
+++ b/apps/server-ts/src/routes/workflows.ts
@@ -47,19 +47,35 @@ const createWorkflowBody = z.object({
 // ─── Helpers ──────────────────────────────
 
 const SENSITIVE_KEYS = ["apiKey", "api_key", "password", "secret", "token", "apiSecret"];
+const SENSITIVE_KEYS_LOWER = new Set(SENSITIVE_KEYS.map((k) => k.toLowerCase()));
+const MAX_STRIP_DEPTH = 20;
+
+/**
+ * Recursively strip sensitive fields (api keys, tokens, passwords) from a
+ * value. Walks nested objects and arrays up to MAX_STRIP_DEPTH to guard against
+ * pathological inputs. Returns a new structure; input is not mutated.
+ */
+function deepStripSensitive(value: unknown, depth = 0): unknown {
+  if (depth >= MAX_STRIP_DEPTH) return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => deepStripSensitive(item, depth + 1));
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+      if (SENSITIVE_KEYS_LOWER.has(key.toLowerCase())) {
+        out[key] = "";
+      } else {
+        out[key] = deepStripSensitive(inner, depth + 1);
+      }
+    }
+    return out;
+  }
+  return value;
+}
 
 function stripApiKeys(nodes: Record<string, unknown>[]): Record<string, unknown>[] {
-  return nodes.map((node) => {
-    const copy = { ...node };
-    if (copy.config && typeof copy.config === "object") {
-      const configCopy = { ...(copy.config as Record<string, unknown>) };
-      for (const key of SENSITIVE_KEYS) {
-        if (key in configCopy) configCopy[key] = "";
-      }
-      copy.config = configCopy;
-    }
-    return copy;
-  });
+  return nodes.map((node) => deepStripSensitive(node) as Record<string, unknown>);
 }
 
 type WorkflowRow = typeof workflows.$inferSelect;
@@ -215,13 +231,28 @@ app.get("/:id/export", async (c) => {
 });
 
 // Import workflow
+const importWorkflowBody = z.object({
+  name: z.string().max(256).optional(),
+  description: z.string().max(2048).optional().nullable(),
+  nodes: z.array(z.record(z.string(), z.unknown())).max(500).optional(),
+  connections: z.array(z.record(z.string(), z.unknown())).max(2000).optional(),
+  character: z.record(z.string(), z.unknown()).optional(),
+});
+
 app.post("/import", async (c) => {
-  let data;
+  let raw;
   try {
-    data = await c.req.json();
+    raw = await c.req.json();
   } catch {
     return c.json({ error: "Invalid JSON in request body" }, 400);
   }
+
+  const parsed = importWorkflowBody.safeParse(raw);
+  if (!parsed.success) {
+    return c.json({ error: "Invalid workflow payload", details: parsed.error.format() }, 400);
+  }
+  const data = parsed.data;
+
   const id = generateId();
   const now = nowISO();
 

--- a/packages/sdk-ts/src/context.ts
+++ b/packages/sdk-ts/src/context.ts
@@ -110,7 +110,10 @@ export class NodeContext {
     if (this._updateCharacterCallback) {
       await this._updateCharacterCallback(updates);
     }
-    Object.assign(this.character, updates);
+    for (const [key, value] of Object.entries(updates)) {
+      if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+      this.character[key] = value;
+    }
   }
 
   /**

--- a/plugins/http-request/manifest.json
+++ b/plugins/http-request/manifest.json
@@ -69,6 +69,28 @@
       "default": 30000,
       "min": 1000,
       "max": 120000
+    },
+    "allowPrivateHosts": {
+      "type": "boolean",
+      "label": "Allow Private / Loopback Hosts",
+      "description": "Permit requests to localhost and RFC1918/link-local addresses. Disabled by default to mitigate SSRF.",
+      "default": false
+    },
+    "maxRedirects": {
+      "type": "number",
+      "label": "Max Redirects",
+      "description": "Maximum number of redirects to follow (0 disables redirects)",
+      "default": 5,
+      "min": 0,
+      "max": 20
+    },
+    "maxResponseBytes": {
+      "type": "number",
+      "label": "Max Response Size (bytes)",
+      "description": "Maximum allowed response body size in bytes",
+      "default": 52428800,
+      "min": 1024,
+      "max": 1073741824
     }
   }
 }

--- a/plugins/http-request/node.ts
+++ b/plugins/http-request/node.ts
@@ -6,11 +6,57 @@
 
 import { BaseNode, type NodeContext } from "@aituber-flow/sdk";
 
+/** Default maximum number of redirects to follow. */
+const DEFAULT_MAX_REDIRECTS = 5;
+/** Default maximum response body size in bytes (50 MB). */
+const DEFAULT_MAX_RESPONSE_BYTES = 50 * 1024 * 1024;
+
+/**
+ * Return true if the hostname points to a loopback, link-local, or RFC1918
+ * private address. Used to block SSRF attempts by default.
+ */
+function isPrivateOrLoopbackHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+
+  if (host === "localhost" || host === "ip6-localhost" || host === "ip6-loopback") return true;
+  if (host === "0.0.0.0" || host === "::" || host === "::0") return true;
+
+  // IPv4 literals
+  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const [a, b] = [Number(v4[1]), Number(v4[2])];
+    if (a === 127) return true; // loopback
+    if (a === 10) return true; // RFC1918
+    if (a === 192 && b === 168) return true; // RFC1918
+    if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918
+    if (a === 169 && b === 254) return true; // link-local (incl. AWS metadata 169.254.169.254)
+    if (a === 0) return true; // "this network"
+    if (a >= 224) return true; // multicast/reserved
+  }
+
+  // IPv6 literals
+  if (host === "::1") return true;
+  if (host.startsWith("fc") || host.startsWith("fd")) return true; // unique local
+  if (host.startsWith("fe80")) return true; // link-local
+  if (host.startsWith("::ffff:")) {
+    // IPv4-mapped IPv6
+    const mapped = host.slice(7);
+    if (mapped.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)) {
+      return isPrivateOrLoopbackHost(mapped);
+    }
+  }
+
+  return false;
+}
+
 export default class HttpRequestNode extends BaseNode {
   private url = "";
   private method = "GET";
   private headers: Record<string, string> = {};
   private timeout = 30000;
+  private allowPrivateHosts = false;
+  private maxRedirects = DEFAULT_MAX_REDIRECTS;
+  private maxResponseBytes = DEFAULT_MAX_RESPONSE_BYTES;
 
   async setup(
     config: Record<string, any>,
@@ -19,6 +65,15 @@ export default class HttpRequestNode extends BaseNode {
     this.url = config.url ?? "";
     this.method = config.method ?? "GET";
     this.timeout = config.timeout ?? 30000;
+    this.allowPrivateHosts = config.allowPrivateHosts === true;
+    this.maxRedirects =
+      typeof config.maxRedirects === "number" && config.maxRedirects >= 0
+        ? Math.min(config.maxRedirects, 20)
+        : DEFAULT_MAX_REDIRECTS;
+    this.maxResponseBytes =
+      typeof config.maxResponseBytes === "number" && config.maxResponseBytes > 0
+        ? config.maxResponseBytes
+        : DEFAULT_MAX_RESPONSE_BYTES;
 
     // Parse headers from JSON string
     const headersStr = config.headers ?? "{}";
@@ -33,6 +88,26 @@ export default class HttpRequestNode extends BaseNode {
     }
 
     await context.log(`HTTP Request configured: ${this.method} ${this.url}`);
+  }
+
+  /**
+   * Validate a URL's scheme and reject SSRF targets unless explicitly allowed.
+   * Returns an error string if rejected, null if OK.
+   */
+  private validateUrl(rawUrl: string): string | null {
+    let parsed: URL;
+    try {
+      parsed = new URL(rawUrl);
+    } catch {
+      return "Invalid URL";
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return `Unsupported protocol: ${parsed.protocol}`;
+    }
+    if (!this.allowPrivateHosts && isPrivateOrLoopbackHost(parsed.hostname)) {
+      return `Refusing to connect to private/loopback host "${parsed.hostname}" (set allowPrivateHosts to enable)`;
+    }
+    return null;
   }
 
   async execute(
@@ -52,53 +127,106 @@ export default class HttpRequestNode extends BaseNode {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), this.timeout);
 
-      const fetchOptions: RequestInit = {
-        method: this.method,
-        headers: { ...this.headers },
-        signal: controller.signal,
+      const buildOptions = (method: string, includeBody: boolean): RequestInit => {
+        const opts: RequestInit = {
+          method,
+          headers: { ...this.headers },
+          signal: controller.signal,
+          redirect: "manual",
+        };
+        if (
+          includeBody &&
+          body !== undefined &&
+          ["POST", "PUT", "PATCH"].includes(method)
+        ) {
+          if (typeof body === "object") {
+            opts.body = JSON.stringify(body);
+            const headerKeys = Object.keys(this.headers).map((k) => k.toLowerCase());
+            if (!headerKeys.includes("content-type")) {
+              (opts.headers as Record<string, string>)["Content-Type"] = "application/json";
+            }
+          } else {
+            opts.body = String(body);
+          }
+        }
+        return opts;
       };
 
-      if (
-        body !== undefined &&
-        ["POST", "PUT", "PATCH"].includes(this.method)
-      ) {
-        if (typeof body === "object") {
-          fetchOptions.body = JSON.stringify(body);
-          // Set Content-Type if not already set
-          const headerKeys = Object.keys(this.headers).map((k) =>
-            k.toLowerCase(),
-          );
-          if (!headerKeys.includes("content-type")) {
-            (fetchOptions.headers as Record<string, string>)["Content-Type"] =
-              "application/json";
-          }
-        } else {
-          fetchOptions.body = String(body);
+      // Manual redirect handling so we can enforce a hop cap and re-validate each target
+      let currentUrl = this.url;
+      let currentMethod = this.method;
+      let response: Response | null = null;
+
+      for (let hop = 0; hop <= this.maxRedirects; hop++) {
+        const validationError = this.validateUrl(currentUrl);
+        if (validationError) {
+          clearTimeout(timeoutId);
+          await context.log(validationError, "error");
+          return { response: null, status: 0 };
         }
+
+        const isFirstHop = hop === 0;
+        response = await fetch(currentUrl, buildOptions(currentMethod, isFirstHop));
+
+        if (response.status < 300 || response.status >= 400) break;
+
+        const location = response.headers.get("location");
+        if (!location) break;
+
+        if (hop === this.maxRedirects) {
+          clearTimeout(timeoutId);
+          await context.log(`Exceeded max redirects (${this.maxRedirects})`, "error");
+          return { response: null, status: 0 };
+        }
+
+        // Per RFC 7231: 301/302/303 convert to GET for cross-method redirects
+        if (
+          (response.status === 301 || response.status === 302 || response.status === 303) &&
+          currentMethod !== "GET" &&
+          currentMethod !== "HEAD"
+        ) {
+          currentMethod = "GET";
+        }
+        currentUrl = new URL(location, currentUrl).toString();
       }
 
-      const response = await fetch(this.url, fetchOptions);
       clearTimeout(timeoutId);
+
+      if (!response) {
+        await context.log("No response received", "error");
+        return { response: null, status: 0 };
+      }
 
       const status = response.status;
 
-      // Try to parse as JSON, fallback to text
-      let data: any;
+      // Enforce response body size limit via Content-Length and streaming read
+      const contentLengthHeader = response.headers.get("content-length");
+      const contentLength = contentLengthHeader ? Number(contentLengthHeader) : NaN;
+      if (Number.isFinite(contentLength) && contentLength > this.maxResponseBytes) {
+        await context.log(
+          `Response body too large: ${contentLength} > ${this.maxResponseBytes}`,
+          "error",
+        );
+        return { response: null, status };
+      }
+
+      const text = await this.readLimitedText(response);
+
+      let data: unknown = text;
       const contentType = response.headers.get("content-type") ?? "";
-      try {
-        if (contentType.includes("application/json")) {
-          data = await response.json();
-        } else {
-          const text = await response.text();
-          // Try parsing text as JSON anyway
-          try {
-            data = JSON.parse(text);
-          } catch {
-            data = text;
-          }
+      if (contentType.includes("application/json")) {
+        try {
+          data = JSON.parse(text);
+        } catch {
+          // keep as text
         }
-      } catch {
-        data = await response.text();
+      } else {
+        // Opportunistic JSON parse for servers with wrong content-type
+        try {
+          data = JSON.parse(text);
+        } catch {
+          data = text;
+        }
       }
 
       await context.log(`Response received: ${status}`);
@@ -111,9 +239,52 @@ export default class HttpRequestNode extends BaseNode {
         );
         return { response: null, status: 0 };
       }
+      if (e instanceof Error && e.message === "Response body exceeded limit") {
+        await context.log(
+          `Response body exceeded ${this.maxResponseBytes} bytes`,
+          "error",
+        );
+        return { response: null, status: 0 };
+      }
       await context.log(`Request failed: ${String(e)}`, "error");
       return { response: null, status: 0 };
     }
+  }
+
+  /**
+   * Read the response body as text while enforcing the maxResponseBytes cap.
+   * Aborts with "Response body exceeded limit" if the cap is crossed.
+   */
+  private async readLimitedText(response: Response): Promise<string> {
+    if (!response.body) return "";
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        received += value.byteLength;
+        if (received > this.maxResponseBytes) {
+          await reader.cancel();
+          throw new Error("Response body exceeded limit");
+        }
+        chunks.push(value);
+      }
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        // already released
+      }
+    }
+    const buffer = new Uint8Array(received);
+    let offset = 0;
+    for (const chunk of chunks) {
+      buffer.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return new TextDecoder().decode(buffer);
   }
 
   async teardown(): Promise<void> {

--- a/tests/routes/workflows.test.ts
+++ b/tests/routes/workflows.test.ts
@@ -442,6 +442,50 @@ describe("Workflow Export / Import", () => {
     expect(exported.nodes[0].config.apiKey).toBe("sk-keep-me");
   });
 
+  it("should strip API keys nested deep inside config (deep strip)", async () => {
+    const created = await createWorkflowViaApi(app, {
+      name: "Deep Secret",
+      nodes: [
+        {
+          id: "n1",
+          type: "custom",
+          config: {
+            nested: {
+              deep: { apiKey: "sk-deep-hidden", harmless: "ok" },
+              authentication: { token: "t-leak" },
+            },
+            headers: { Authorization: "keep" }, // not in sensitive list
+            api_key: "snake-case-secret",
+          },
+        },
+      ],
+    });
+
+    const res = await app.request(
+      new Request(`http://localhost/api/workflows/${created.id}/export`, {
+        method: "GET",
+      })
+    );
+    expect(res.status).toBe(200);
+    const exported = await res.json();
+    const cfg = exported.nodes[0].config;
+    expect(cfg.nested.deep.apiKey).toBe("");
+    expect(cfg.nested.deep.harmless).toBe("ok");
+    expect(cfg.nested.authentication.token).toBe("");
+    expect(cfg.api_key).toBe("");
+    // Non-sensitive fields preserved
+    expect(cfg.headers.Authorization).toBe("keep");
+  });
+
+  it("should reject import with invalid payload shape", async () => {
+    const res = await app.request(
+      jsonRequest("POST", "/api/workflows/import", {
+        nodes: "not an array", // invalid
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("should import a workflow", async () => {
     const importData = {
       name: "Imported Flow",

--- a/tests/sdk/context.test.ts
+++ b/tests/sdk/context.test.ts
@@ -216,6 +216,25 @@ describe("NodeContext", () => {
     expect(updates[0]).toEqual({ mood: "happy", topic: "cooking" });
   });
 
+  it("updateCharacter refuses __proto__/constructor keys (prototype pollution guard)", async () => {
+    const ctx = new NodeContext({
+      workflowId: "wf-1",
+      nodeId: "n-1",
+      character: { name: "Bot" },
+    });
+
+    const malicious = JSON.parse('{"__proto__": {"polluted": true}, "mood": "ok"}');
+    await ctx.updateCharacter(malicious);
+
+    expect(ctx.character.mood).toBe("ok");
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+
+    await ctx.updateCharacter({ constructor: { malicious: true } } as Record<string, any>);
+    // Object prototype should not be overwritten
+    expect(({}).constructor).toBe(Object);
+  });
+
   it("createTask returns AbortController and cleans up", async () => {
     const ctx = new NodeContext({
       workflowId: "wf-1",


### PR DESCRIPTION
## 概要

issue #148 で列挙したセキュリティ脆弱性を修正。

## 変更内容

### プロトタイプ汚染ガード
- \`apps/server-ts/src/engine/executor.ts\`: \`NodeContext.updateCharacter\` で \`__proto__\`/\`constructor\`/\`prototype\` キーを除外
- \`packages/sdk-ts/src/context.ts\`: 同上（SDK 側の NodeContext も）
- テスト: \`tests/sdk/context.test.ts\` にプロトタイプ汚染ガードテスト追加

### Tauri Content Security Policy
- \`apps/desktop/src-tauri/tauri.conf.json\`: \`csp: null\` を strict CSP へ変更
  - \`default-src 'self'\`, \`object-src 'none'\`, \`base-uri 'self'\`, \`frame-ancestors 'none'\` を含む
  - 外部 LLM API (OpenAI, Anthropic, Google, Groq, Mistral) と YouTube API は connect-src で許可
  - Next.js 静的エクスポートが inline スクリプト/スタイルを使うため \`'unsafe-inline'\` は維持（完全除去は別PRで検討）

### HTTP-Request プラグインの SSRF + DoS 対策
- \`plugins/http-request/node.ts\`: 全面書き直し
  - URL 検証: 127.x, 10.x, 192.168.x, 172.16-31.x, 169.254.x, ::1, fc/fd/fe80, link-local を拒否 (\`allowPrivateHosts: true\` で解除可能)
  - レスポンスサイズ上限: Content-Length チェック＋ストリーミング時上限突破で abort (\`maxResponseBytes\`, デフォルト 50MB)
  - リダイレクト上限: \`redirect: \"manual\"\` + 手動追跡で最大回数 (\`maxRedirects\`, デフォルト 5)
- \`plugins/http-request/manifest.json\`: 新規 config (\`allowPrivateHosts\`, \`maxRedirects\`, \`maxResponseBytes\`)

### Workflow Import バリデーション
- \`apps/server-ts/src/routes/workflows.ts\`: \`POST /import\` に Zod スキーマを追加
  - 配列長上限（nodes: 500, connections: 2000）で JSON 爆弾を防ぐ

### 機密フィールドの深い除去
- \`apps/server-ts/src/routes/workflows.ts\`: \`stripApiKeys\` を再帰化
  - 大小無視で \`apiKey\`, \`api_key\`, \`password\`, \`secret\`, \`token\`, \`apiSecret\` を空文字に
  - ネスト深度 20 まで走査

## テスト計画
- [x] \`bun test tests/\` 全203テスト通過
- [x] \`tests/sdk/context.test.ts\` にプロトタイプ汚染テスト追加
- [x] \`tests/routes/workflows.test.ts\` に deep-strip とインポート不正ペイロードテスト追加
- [x] 全 typecheck (server-ts / sdk-ts / web) 通過
- [ ] デスクトップビルドで新 CSP が動作することを手動確認（要別途）

closes #148