### PR TITLE
fix: バックエンドの信頼性バグを修正 (#149)

### DIFF
--- a/apps/server-ts/src/db/database.ts
+++ b/apps/server-ts/src/db/database.ts
@@ -9,6 +9,19 @@ sqlite.exec("PRAGMA journal_mode = WAL");
 
 export const db = drizzle(sqlite, { schema });
 
+/**
+ * Close the underlying SQLite handle. Call during graceful shutdown to flush
+ * the WAL and release file locks.
+ */
+export function closeDb(): void {
+  try {
+    sqlite.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+  } catch {
+    // ignore — the close below still completes
+  }
+  sqlite.close();
+}
+
 const CREATE_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS workflows (
     id TEXT PRIMARY KEY,

--- a/apps/server-ts/src/engine/executor.ts
+++ b/apps/server-ts/src/engine/executor.ts
@@ -294,6 +294,10 @@ export class WorkflowExecutor {
 
   // ─── Status ───────────────────────
 
+  getRunningWorkflowIds(): string[] {
+    return [...this.runningWorkflows.keys()];
+  }
+
   getStatus(workflowId: string): Record<string, unknown> {
     const status = this.runningWorkflows.get(workflowId);
     if (!status) return { status: "idle" };
@@ -551,9 +555,16 @@ export class WorkflowExecutor {
         workflow_data: data,
       });
 
-      // Start execution in background (non-blocking)
+      // Start execution in background (non-blocking). Errors here reach the
+      // top-level promise; record them on the workflow status so the HTTP
+      // /status endpoint and WebSocket clients can observe the failure.
       this.executeWorkflow(workflowId, data).catch((err) => {
         console.error("Workflow execution error:", err);
+        const status = this.runningWorkflows.get(workflowId);
+        if (status) {
+          status.status = "error";
+          status.error = err instanceof Error ? err.message : String(err);
+        }
       });
 
       console.log(`Started workflow: ${workflowId}`);

--- a/apps/server-ts/src/index.ts
+++ b/apps/server-ts/src/index.ts
@@ -6,7 +6,7 @@ import { createBunWebSocket } from "hono/bun";
 import { serveStatic } from "hono/bun";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
-import { initDb } from "./db/database";
+import { closeDb, initDb } from "./db/database";
 import { WorkflowExecutor } from "./engine/executor";
 import { integrationRoutes } from "./routes/integrations";
 import { pluginRoutes } from "./routes/plugins";
@@ -112,13 +112,48 @@ const port = Number.isFinite(parsedPort) ? parsedPort : 8001;
 console.log(`Started development server: http://localhost:${port}`);
 
 // Graceful shutdown handler
-process.on("SIGTERM", () => {
-  console.log("Received SIGTERM, shutting down gracefully...");
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+let isShuttingDown = false;
+
+async function gracefulShutdown(signal: string): Promise<void> {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  console.log(`Received ${signal}, shutting down gracefully...`);
+
+  const timeoutHandle = setTimeout(() => {
+    console.warn(`Shutdown timed out after ${SHUTDOWN_TIMEOUT_MS}ms, forcing exit`);
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS);
+  // Don't let the timeout keep the process alive if everything finishes fast.
+  if (typeof timeoutHandle === "object" && "unref" in timeoutHandle) {
+    timeoutHandle.unref();
+  }
+
+  try {
+    const runningIds = executor.getRunningWorkflowIds();
+    if (runningIds.length > 0) {
+      console.log(`Stopping ${runningIds.length} running workflow(s)...`);
+      await Promise.allSettled(runningIds.map((id) => executor.stopWorkflow(id)));
+    }
+  } catch (err) {
+    console.error("Error stopping workflows on shutdown:", err);
+  }
+
+  try {
+    closeDb();
+  } catch (err) {
+    console.error("Error closing database on shutdown:", err);
+  }
+
+  clearTimeout(timeoutHandle);
   process.exit(0);
+}
+
+process.on("SIGTERM", () => {
+  void gracefulShutdown("SIGTERM");
 });
 process.on("SIGINT", () => {
-  console.log("Received SIGINT, shutting down gracefully...");
-  process.exit(0);
+  void gracefulShutdown("SIGINT");
 });
 
 // Use export default for Bun's built-in server management.

--- a/apps/server-ts/src/routes/workflows.ts
+++ b/apps/server-ts/src/routes/workflows.ts
@@ -322,17 +322,32 @@ app.post("/:id/start", async (c) => {
   const [existing] = await _db.select().from(workflows).where(eq(workflows.id, id));
   if (!existing) return c.json({ detail: "Workflow not found" }, 404);
 
-  let body: any = {};
-  try {
-    body = await c.req.json();
-  } catch {
-    // No body provided
+  // Distinguish "no body" (fine) from "malformed body" (reject).
+  // Hono's c.req.text() resolves to "" when no body was sent, letting us
+  // skip the JSON parse in that case. Malformed JSON still gets a 400.
+  let body: Record<string, unknown> = {};
+  const rawBody = await c.req.text();
+  if (rawBody.trim().length > 0) {
+    try {
+      const parsed = JSON.parse(rawBody) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        body = parsed as Record<string, unknown>;
+      } else {
+        return c.json({ error: "Request body must be a JSON object" }, 400);
+      }
+    } catch {
+      return c.json({ error: "Invalid JSON in request body" }, 400);
+    }
   }
 
-  const nodes = body.nodes ?? JSON.parse(existing.nodesJson || "[]");
-  const connections = body.connections ?? JSON.parse(existing.connectionsJson || "[]");
-  const character = body.character ?? JSON.parse(existing.characterJson || "{}");
-  const startNodeId = body.startNodeId ?? null;
+  const nodes = (body.nodes as unknown[] | undefined) ?? JSON.parse(existing.nodesJson || "[]");
+  const connections =
+    (body.connections as unknown[] | undefined) ??
+    JSON.parse(existing.connectionsJson || "[]");
+  const character =
+    (body.character as Record<string, unknown> | undefined) ??
+    JSON.parse(existing.characterJson || "{}");
+  const startNodeId = typeof body.startNodeId === "string" ? body.startNodeId : null;
 
   const workflowData = {
     id: existing.id,

--- a/tests/routes/workflows.test.ts
+++ b/tests/routes/workflows.test.ts
@@ -550,6 +550,18 @@ describe("Workflow Execution", () => {
     expect(data.workflow_id).toBe(created.id);
   });
 
+  it("should reject start with malformed JSON body", async () => {
+    const created = await createWorkflowViaApi(app, { name: "Bad body" });
+    const res = await app.request(
+      new Request(`http://localhost/api/workflows/${created.id}/start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not valid json",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("should return 404 when starting non-existent workflow", async () => {
     const fakeId = "00000000-0000-0000-0000-000000000000";
     const res = await app.request(


### PR DESCRIPTION
## 概要

issue #149 に記載したバックエンド信頼性バグを修正。

## 変更内容

- **graceful shutdown** (\`apps/server-ts/src/index.ts\`): SIGTERM/SIGINT で実行中ワークフローを停止しDBをクローズしてから終了する。10 秒タイムアウトで強制終了へのフォールバックあり。
- **DB クローズ** (\`apps/server-ts/src/db/database.ts\`): \`closeDb()\` を公開、WAL \`TRUNCATE\` チェックポイント後にクローズ。
- **executor.getRunningWorkflowIds()** (\`apps/server-ts/src/engine/executor.ts\`): シャットダウン処理が対象ワークフローを列挙できるよう追加。
- **startWorkflow エラー可視化** (\`apps/server-ts/src/engine/executor.ts\`): \`executeWorkflow\` の fire-and-forget 失敗時に \`runningWorkflows\` の status を \"error\" + error メッセージで更新。
- **workflow /start の JSON 検証** (\`apps/server-ts/src/routes/workflows.ts\`): 不正 JSON/配列/非オブジェクトボディを 400 で拒否。従来は \`{}\` フォールバックしていた。

## テスト計画
- [x] 新テスト: workflow start 時の malformed JSON → 400
- [x] 全204 テスト通過（\`bun test tests/\`）
- [x] backend typecheck 通過
- [ ] 手動: Ctrl+C でサーバー終了時に WAL チェックポイントが走ることを確認（要別途）

closes #149