### PR TITLE
fix: プラグインの信頼性バグを修正 (#150)

### DIFF
--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -53,5 +53,5 @@ export {
 } from "./errors";
 
 // LLM error utilities
-export { handleLLMError, classifyLLMError } from "./llm-utils";
+export { handleLLMError, classifyLLMError, clampTemperature } from "./llm-utils";
 export type { LLMErrorCategory, LLMErrorResult } from "./llm-utils";

--- a/packages/sdk-ts/src/llm-utils.ts
+++ b/packages/sdk-ts/src/llm-utils.ts
@@ -119,3 +119,18 @@ export async function handleLLMError(
     }
   }
 }
+
+/**
+ * Clamp a temperature value to the valid range [0, 2]. Non-finite, null,
+ * undefined, or empty-string inputs fall back to the provided default rather
+ * than silently coercing to 0.
+ */
+export function clampTemperature(value: unknown, fallback = 0.7): number {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === "string" && value.trim() === "") return fallback;
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  if (n < 0) return 0;
+  if (n > 2) return 2;
+  return n;
+}

--- a/plugins/anthropic-llm/node.ts
+++ b/plugins/anthropic-llm/node.ts
@@ -4,7 +4,13 @@
  * Generates text using Anthropic's Claude models.
  */
 
-import { BaseNode, NodeContext, createEvent, handleLLMError } from "@aituber-flow/sdk";
+import {
+  BaseNode,
+  NodeContext,
+  clampTemperature,
+  createEvent,
+  handleLLMError,
+} from "@aituber-flow/sdk";
 import Anthropic from "@anthropic-ai/sdk";
 
 export default class AnthropicLLMNode extends BaseNode {
@@ -24,7 +30,7 @@ export default class AnthropicLLMNode extends BaseNode {
     this.model = config.model ?? "claude-3-haiku-20240307";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.maxTokens = config.maxTokens ?? 1024;
-    this.temperature = config.temperature ?? 0.7;
+    this.temperature = clampTemperature(config.temperature, 0.7);
 
     if (!this.apiKey) {
       // Auto demo mode when API key is not set
@@ -61,6 +67,7 @@ export default class AnthropicLLMNode extends BaseNode {
       const message = await this.client.messages.create({
         model: this.model,
         max_tokens: this.maxTokens,
+        temperature: this.temperature,
         system: this.systemPrompt,
         messages: [{ role: "user" as const, content: prompt }],
       });

--- a/plugins/delay/node.ts
+++ b/plugins/delay/node.ts
@@ -11,6 +11,7 @@ export default class DelayNode extends BaseNode {
   private randomize = false;
   private randomMin = 500;
   private randomMax = 2000;
+  private pendingControllers = new Set<AbortController>();
 
   async setup(config: Record<string, any>, context: NodeContext): Promise<void> {
     this.delayMs = config.delayMs ?? 1000;
@@ -33,7 +34,6 @@ export default class DelayNode extends BaseNode {
   ): Promise<Record<string, any>> {
     const inputData = inputs.input;
 
-    // Calculate delay
     let delay: number;
     if (this.randomize) {
       delay =
@@ -43,14 +43,41 @@ export default class DelayNode extends BaseNode {
       delay = this.delayMs;
     }
 
+    const controller = new AbortController();
+    this.pendingControllers.add(controller);
     await context.log(`Waiting ${delay}ms...`);
-    await new Promise((resolve) => setTimeout(resolve, delay));
-    await context.log("Delay complete");
 
-    return { output: inputData };
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          this.pendingControllers.delete(controller);
+          resolve();
+        }, delay);
+        controller.signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            this.pendingControllers.delete(controller);
+            reject(new DOMException("Delay aborted", "AbortError"));
+          },
+          { once: true },
+        );
+      });
+      await context.log("Delay complete");
+      return { output: inputData };
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        await context.log("Delay cancelled", "warning");
+      }
+      throw err;
+    }
   }
 
   async teardown(): Promise<void> {
-    // No cleanup needed.
+    // Cancel any outstanding delays so the timer doesn't fire after stop.
+    for (const controller of this.pendingControllers) {
+      controller.abort();
+    }
+    this.pendingControllers.clear();
   }
 }

--- a/plugins/google-llm/node.ts
+++ b/plugins/google-llm/node.ts
@@ -4,7 +4,13 @@
  * Generates text using Google's Gemini models.
  */
 
-import { BaseNode, NodeContext, createEvent, handleLLMError } from "@aituber-flow/sdk";
+import {
+  BaseNode,
+  NodeContext,
+  clampTemperature,
+  createEvent,
+  handleLLMError,
+} from "@aituber-flow/sdk";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
 export default class GoogleLLMNode extends BaseNode {
@@ -24,7 +30,7 @@ export default class GoogleLLMNode extends BaseNode {
     this.model = config.model ?? "gemini-1.5-flash";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.maxTokens = config.maxTokens ?? 1024;
-    this.temperature = config.temperature ?? 0.7;
+    this.temperature = clampTemperature(config.temperature, 0.7);
 
     if (!this.apiKey) {
       // Auto demo mode when API key is not set

--- a/plugins/groq-llm/node.ts
+++ b/plugins/groq-llm/node.ts
@@ -5,7 +5,13 @@
  * Uses OpenAI-compatible API format with custom baseURL.
  */
 
-import { BaseNode, NodeContext, createEvent, handleLLMError } from "@aituber-flow/sdk";
+import {
+  BaseNode,
+  NodeContext,
+  clampTemperature,
+  createEvent,
+  handleLLMError,
+} from "@aituber-flow/sdk";
 import type { Event } from "@aituber-flow/sdk";
 import OpenAI from "openai";
 
@@ -29,7 +35,7 @@ export default class GroqLLMNode extends BaseNode {
     const apiKey = config.apiKey ?? "";
     this.model = config.model ?? "llama-3.3-70b-versatile";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
-    this.temperature = config.temperature ?? 0.7;
+    this.temperature = clampTemperature(config.temperature, 0.7);
     this.maxTokens = config.maxTokens ?? 1024;
     this.promptSections = config.promptSections ?? null;
 

--- a/plugins/mistral-llm/node.ts
+++ b/plugins/mistral-llm/node.ts
@@ -5,7 +5,13 @@
  * Uses OpenAI-compatible API format with custom baseURL.
  */
 
-import { BaseNode, NodeContext, createEvent, handleLLMError } from "@aituber-flow/sdk";
+import {
+  BaseNode,
+  NodeContext,
+  clampTemperature,
+  createEvent,
+  handleLLMError,
+} from "@aituber-flow/sdk";
 import OpenAI from "openai";
 
 interface PromptSection {
@@ -28,7 +34,7 @@ export default class MistralLLMNode extends BaseNode {
     const apiKey = config.apiKey ?? "";
     this.model = config.model ?? "mistral-small-latest";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
-    this.temperature = config.temperature ?? 0.7;
+    this.temperature = clampTemperature(config.temperature, 0.7);
     this.maxTokens = config.maxTokens ?? 1024;
     this.promptSections = config.promptSections ?? null;
 

--- a/plugins/ollama-llm/node.ts
+++ b/plugins/ollama-llm/node.ts
@@ -4,7 +4,13 @@
  * Generates text using Ollama local LLM server.
  */
 
-import { BaseNode, NodeContext, createEvent, handleLLMError } from "@aituber-flow/sdk";
+import {
+  BaseNode,
+  NodeContext,
+  clampTemperature,
+  createEvent,
+  handleLLMError,
+} from "@aituber-flow/sdk";
 
 interface OllamaGenerateResponse {
   response: string;
@@ -27,7 +33,7 @@ export default class OllamaLLMNode extends BaseNode {
     this.host = config.host ?? "http://localhost:11434";
     this.model = config.model ?? "llama3.2";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
-    this.temperature = config.temperature ?? 0.7;
+    this.temperature = clampTemperature(config.temperature, 0.7);
     this.contextLength = config.contextLength ?? 4096;
 
     // Test connection - auto demo mode if unavailable

--- a/plugins/openai-llm/node.ts
+++ b/plugins/openai-llm/node.ts
@@ -4,7 +4,13 @@
  * Generates text responses using OpenAI's GPT models.
  */
 
-import { BaseNode, NodeContext, createEvent, handleLLMError } from "@aituber-flow/sdk";
+import {
+  BaseNode,
+  NodeContext,
+  clampTemperature,
+  createEvent,
+  handleLLMError,
+} from "@aituber-flow/sdk";
 import type { Event } from "@aituber-flow/sdk";
 import OpenAI from "openai";
 
@@ -46,7 +52,7 @@ export default class OpenAILLMNode extends BaseNode {
     this.apiKey = config.apiKey ?? "";
     this.model = config.model ?? "gpt-4o-mini";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
-    this.temperature = config.temperature ?? 0.7;
+    this.temperature = clampTemperature(config.temperature, 0.7);
     this.maxTokens = config.maxTokens ?? 1024;
     this.reasoningEffort = config.reasoningEffort ?? null;
     this.promptSections = config.promptSections ?? null;

--- a/plugins/switch/node.ts
+++ b/plugins/switch/node.ts
@@ -69,8 +69,14 @@ export default class SwitchNode extends BaseNode {
     return strValue.toLowerCase().includes(compare.toLowerCase());
   }
 
+  /** Cap pattern/input length to mitigate catastrophic regex backtracking. */
+  private static readonly MAX_REGEX_PATTERN_LENGTH = 512;
+  private static readonly MAX_REGEX_INPUT_LENGTH = 64 * 1024;
+
   private _compareRegex(value: any, pattern: string): boolean {
+    if (pattern.length > SwitchNode.MAX_REGEX_PATTERN_LENGTH) return false;
     const strValue = value != null ? String(value) : "";
+    if (strValue.length > SwitchNode.MAX_REGEX_INPUT_LENGTH) return false;
     try {
       const flags = this.caseSensitive ? "" : "i";
       const regex = new RegExp(pattern, flags);

--- a/plugins/variable/node.ts
+++ b/plugins/variable/node.ts
@@ -30,14 +30,19 @@ export default class VariableNode extends BaseNode {
       value = this.defaultValue;
     }
 
-    // Convert to the specified type
+    // Convert to the specified type. On failure, fall back to defaultValue so
+    // downstream nodes never see a type-mismatched value masquerading as the
+    // requested type.
     try {
       if (this.valueType === "number") {
         const strValue = String(value);
-        value = strValue.includes(".") ? parseFloat(strValue) : parseInt(strValue, 10);
-        if (isNaN(value)) {
+        const parsed = strValue.includes(".")
+          ? parseFloat(strValue)
+          : parseInt(strValue, 10);
+        if (Number.isNaN(parsed)) {
           throw new Error(`Cannot convert "${strValue}" to number`);
         }
+        value = parsed;
       } else if (this.valueType === "boolean") {
         if (typeof value === "string") {
           value = ["true", "1", "yes"].includes(value.toLowerCase());
@@ -53,7 +58,11 @@ export default class VariableNode extends BaseNode {
         value = String(value);
       }
     } catch (e) {
-      await context.log(`Type conversion failed: ${e}`, "warning");
+      await context.log(
+        `Type conversion to "${this.valueType}" failed (${e instanceof Error ? e.message : String(e)}); using defaultValue`,
+        "warning",
+      );
+      value = this.defaultValue;
     }
 
     await context.log(`Variable '${this.name}' = ${value}`);

--- a/tests/sdk/llm-utils.test.ts
+++ b/tests/sdk/llm-utils.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, mock } from "bun:test";
 import {
+  clampTemperature,
   classifyLLMError,
   handleLLMError,
 } from "../../packages/sdk-ts/src/llm-utils";
@@ -163,5 +164,32 @@ describe("handleLLMError", () => {
     const ctx = createMockContext();
     const result = await handleLLMError("string error", "OpenAI", ctx);
     expect(result.response).toContain("string error");
+  });
+});
+
+describe("clampTemperature", () => {
+  it("returns valid numbers unchanged", () => {
+    expect(clampTemperature(0)).toBe(0);
+    expect(clampTemperature(0.7)).toBe(0.7);
+    expect(clampTemperature(2)).toBe(2);
+  });
+
+  it("clamps to [0, 2]", () => {
+    expect(clampTemperature(-1)).toBe(0);
+    expect(clampTemperature(5)).toBe(2);
+  });
+
+  it("coerces numeric strings", () => {
+    expect(clampTemperature("0.5")).toBe(0.5);
+    expect(clampTemperature("1.5")).toBe(1.5);
+  });
+
+  it("falls back when not a finite number", () => {
+    expect(clampTemperature(undefined)).toBe(0.7);
+    expect(clampTemperature(null)).toBe(0.7);
+    expect(clampTemperature("abc")).toBe(0.7);
+    expect(clampTemperature(Number.NaN)).toBe(0.7);
+    expect(clampTemperature(Number.POSITIVE_INFINITY)).toBe(0.7);
+    expect(clampTemperature(undefined, 0.3)).toBe(0.3);
   });
 });


### PR DESCRIPTION
## 概要

issue #150 に記載したプラグイン単位の信頼性バグを修正。

## 変更内容

### delay ノード (plugins/delay/node.ts)
- AbortController で保留中の setTimeout を追跡
- \`teardown()\` で全保留中の delay を \`DOMException(\"Delay aborted\", \"AbortError\")\` で中断
- これによりワークフロー停止後に setTimeout が発火して context.log などを呼ぶことを防ぐ

### variable ノード (plugins/variable/node.ts)
- 型変換 (number/boolean/json) 失敗時に defaultValue にフォールバック
- 従来は警告を出すだけで変換前の値を返していたため、下流ノードが型不一致でクラッシュする可能性があった
- ログメッセージも具体化

### switch ノード (plugins/switch/node.ts)
- regex モードの catastrophic backtracking 緩和
  - パターン長 512 文字を超える場合は false
  - 入力長 64KB を超える場合は false
- 完全な ReDoS 対策ではないがユーザーコンフィグ由来のハングを抑制

### LLM プラグイン全般
- SDK に \`clampTemperature(value, fallback)\` ヘルパーを追加 (\`packages/sdk-ts/src/llm-utils.ts\`)
- \`openai-llm\`, \`anthropic-llm\`, \`google-llm\`, \`ollama-llm\`, \`groq-llm\`, \`mistral-llm\` 全てが temperature を clampTemperature 経由で読み込むように変更
- 範囲 \`[0, 2]\`、null/undefined/空文字列は fallback (0.7)
- Anthropic: 従来 API パラメータから temperature が抜けていたため追加

## テスト計画
- [x] SDK に \`clampTemperature\` の単体テスト追加 (4 ケース)
- [x] 全 208 テスト通過
- [x] SDK / backend 両方の typecheck 通過

closes #150