### PR TITLE
fix: macOS の Auto-Updater が機能するよう bundle.targets に "app" を追加

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "nsis"],
+    "targets": ["app", "dmg", "nsis"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## 概要

本番 macOS ユーザーの Auto-Updater が **完全に機能していなかった** 重大な問題を修正します。

### 何が壊れていたか

`apps/desktop/src-tauri/tauri.conf.json` の `bundle.targets` が `["dmg", "nsis"]` のみで `"app"` が含まれていませんでした。Tauri ビルドは:

1. `.app` を生成
2. `.dmg` を bundle (中身は `.app`)
3. `bundle.targets` に `"app"` が無いため `.app` を **Cleaning (削除)**
4. 結果として updater 用の `.app.tar.gz` が生成されない

このため、本番 manifest:
```
https://github.com/oboroge0/AITuberFlow/releases/latest/download/latest.json
```
の `platforms` キーには `windows-x86_64` しか存在せず、macOS ユーザーは Tauri Updater が「対応プラットフォームなし」と判定し、新バージョンの通知を一切受け取れない状態でした。

### ユーザー影響

- ❌ macOS ユーザー (Apple Silicon / Intel どちらも): Auto-Updater **完全に機能しない**
- ✅ Windows ユーザー: 既存通り正常 (`nsis` target が updater 対応のため)

### 修正内容

```diff
// apps/desktop/src-tauri/tauri.conf.json
   "bundle": {
     "active": true,
-    "targets": ["dmg", "nsis"],
+    "targets": ["app", "dmg", "nsis"],
```

### 修正後の挙動

`npm run build` 実行時に以下が生成されます:
- `bundle/macos/AITuberFlow.app` (clean されず保持)
- `bundle/macos/AITuberFlow.app.tar.gz` (updater artifact, 約 44MB)
- `bundle/macos/AITuberFlow.app.tar.gz.sig` (CI で `TAURI_SIGNING_PRIVATE_KEY` secret により署名)
- `bundle/dmg/AITuberFlow_X.X.X_aarch64.dmg` (既存の DMG も維持)

次回リリース以降、`latest.json` の `platforms` に以下が含まれるようになります:
- `darwin-aarch64` (Apple Silicon)
- `darwin-x86_64` (Intel Mac)

### v2.3.1 以前の macOS ユーザーへの注意 ⚠️

v2.3.1 自体に macOS updater エントリが存在しないため、v2.3.1 以前のユーザーは
**今回のリリース (v2.3.2 等) への自動更新を受け取れません**。リリースノートで
「macOS ユーザーは今回限り手動再ダウンロードをお願いします」と明記してください。
v2.3.2 以降は自動で更新を受け取れるようになります。

## 検証

- [x] ローカルで `cd apps/desktop && npm run build` 実行
- [x] `bundle/macos/AITuberFlow.app.tar.gz` (44MB) が生成されることを確認
- [x] `bundle/macos/AITuberFlow.app` が dmg 化後も保持されることを確認
- [x] `bundle/dmg/AITuberFlow_2.3.1_aarch64.dmg` が引き続き生成されることを確認

ローカルでは `TAURI_SIGNING_PRIVATE_KEY` 未設定のため `.sig` 生成エラーで終わるが、
CI には secret が設定済みのため本番リリース時は問題なし。

## テスト計画

- [ ] このブランチを元に v2.3.2 等のタグを切り、CI で desktop-release.yml が完走することを確認
- [ ] リリース後に `curl https://github.com/oboroge0/AITuberFlow/releases/latest/download/latest.json` で
      `platforms.darwin-aarch64` と `platforms.darwin-x86_64` のエントリが含まれることを確認
- [ ] v2.3.2 を新規インストールした macOS で次回更新時に Updater 通知が出ることを確認 (将来リリース時)

## ロールバック

1行 revert で完全復元可能。データマイグレーション・副作用なし。

## 副次的影響

- ビルド成果物のディスク使用量が `.app.tar.gz` ぶん (約 44MB × 2 アーキ) 増加
- 既存の Windows ユーザー体験には影響なし
- `Cargo.toml` のバージョン (2.2.1) と他ファイル (2.3.1) の不一致は別Issue (#1) として fix-plan.md に記録、別 PR で対応予定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated desktop application build configuration to support additional distribution format.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oboroge0/AITuberFlow/pull/161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->