### PR TITLE
chore: バージョンを 2.3.1 に統一しリリース手順 doc を更新 (Issue #1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,11 +256,16 @@ docs: プラグイン開発ガイドを更新
 
 ### 2. バージョン更新
 
-以下のファイルのバージョンを更新:
+以下のファイルのバージョンを更新 (5ファイル全て揃えること):
 - `apps/web/package.json`
 - `apps/server-ts/package.json`
+- `apps/desktop/package.json`
 - `apps/desktop/src-tauri/tauri.conf.json`
+- `apps/desktop/src-tauri/Cargo.toml` (更新後 `cd apps/desktop/src-tauri && cargo update -p aituber-flow` で Cargo.lock も更新)
 - `CHANGELOG.md`（日付は `date +%Y-%m-%d` で確認）
+
+⚠️ 過去のリリースで `apps/desktop/package.json` (2.0.0 のまま) と `Cargo.toml` (パッチずれ) の
+更新漏れが続いていた。Updater 判定の不安定や成果物バージョン文字列の齟齬を防ぐため必ず全て揃える。
 
 ### 3. コミット＆マージ
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aituber-flow/desktop",
-  "version": "2.0.0",
+  "version": "2.3.1",
   "private": true,
   "scripts": {
     "prepare-runtime": "cd ../web && npm run build:desktop && cd ../desktop && node scripts/build-sidecar.js && node scripts/copy-resources.js",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aituber-flow"
-version = "2.2.1"
+version = "2.3.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aituber-flow"
-version = "2.2.1"
+version = "2.3.1"
 description = "AITuberFlow Desktop - Visual workflow editor for AI VTuber streaming"
 authors = ["AITuberFlow"]
 edition = "2021"


### PR DESCRIPTION
## 概要

`apps/desktop/package.json` (2.0.0) と `apps/desktop/src-tauri/Cargo.toml` (2.2.1) が
他ファイル (2.3.1) とバージョン不一致だったため統一します。CLAUDE.md のリリース手順
にも該当ファイルを追記して再発防止します。

## 発見経緯

検証中に `grep version` で全パッケージのバージョン文字列を比較したところ、5ファイルで
3つの異なる値が混在していることが判明:

| ファイル | 修正前 | 修正後 |
|---------|--------|--------|
| `apps/web/package.json` | 2.3.1 | 2.3.1 (変更なし) |
| `apps/server-ts/package.json` | 2.3.1 | 2.3.1 (変更なし) |
| `apps/desktop/src-tauri/tauri.conf.json` | 2.3.1 | 2.3.1 (変更なし) |
| `apps/desktop/src-tauri/Cargo.toml` | **2.2.1** | **2.3.1** |
| `apps/desktop/package.json` | **2.0.0** | **2.3.1** |
| `apps/desktop/src-tauri/Cargo.lock` | aituber-flow 2.2.1 | aituber-flow 2.3.1 |

## 根本原因

`CLAUDE.md` のリリース手順章 (### 2. バージョン更新) で更新ファイルとして列挙されていたのは
3ファイルのみで、`apps/desktop/package.json` と `apps/desktop/src-tauri/Cargo.toml` が
抜けていた。手順書通りに作業すると 2ファイルが更新されないまま releaseされる構造的問題。

## 影響範囲

- 機能・挙動の変化はなし
- 次回ビルド時の Cargo.lock 内 `aituber-flow` のバージョンが他と揃う
- リリース手順を遵守すれば今後はバージョン齟齬が発生しない
- 実際にはどちらも `tauri.conf.json` のバージョンが優先されてビルドされるため、
  ユーザー視認のバージョン文字列 (DMG 名 `AITuberFlow_2.3.1_aarch64.dmg` 等) は元から正しかった
- ただし Updater のバージョン判定や CHANGELOG 記述との整合性で混乱の元なので統一推奨

## 検証

- [x] `cargo update -p aituber-flow --offline` で Cargo.lock を同期
- [x] `git diff` で変更が想定通り (4 files, 9 +/- 4) であることを確認

## ロールバック

revert で完全復元可能。データ・成果物への影響なし。

## 関連

- このリポジトリの検証で発見された 7件の Issue のうち #1 を修正
- 別 PR #161 (macOS Updater 修正) と独立、merge 順序は問わない
- 他の Issue (#2 CSP, #3 devtools, #4 bundle id, #7 sidecar orphan) は別 PR で対応予定