### PR TITLE
refactor: devtools 機能を Cargo features 化し release ビルドから除外 (Issue #3)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prepare-runtime": "cd ../web && npm run build:desktop && cd ../desktop && node scripts/build-sidecar.js && node scripts/copy-resources.js",
-    "dev": "npm run prepare-runtime && tauri dev",
+    "dev": "npm run prepare-runtime && tauri dev --features devtools",
     "build": "npm run prepare-runtime && tauri build",
     "build-sidecar": "node scripts/build-sidecar.js",
     "copy-resources": "node scripts/copy-resources.js",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -12,8 +12,14 @@ crate-type = ["lib", "cdylib", "staticlib"]
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
+[features]
+# devtools 機能 (WebView インスペクタ等) は dev 時のみ有効化。
+# release ビルドでは feature を渡さないため、エンドユーザーが内部 IPC を直接実行できない。
+# dev で有効化するには `tauri dev --features devtools` (apps/desktop/package.json の dev スクリプト参照)。
+devtools = ["tauri/devtools"]
+
 [dependencies]
-tauri = { version = "2", features = ["devtools"] }
+tauri = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"


### PR DESCRIPTION
## 概要

これまで `apps/desktop/src-tauri/Cargo.toml` で:
```toml
tauri = { version = "2", features = ["devtools"] }
```
として devtools 機能を常時有効化していたため、release ビルド (本番配布版) でも
エンドユーザーが WebView の DevTools にアクセスできる状態でした。

## 問題

本番ビルドで devtools が有効になっていることで以下のリスクがありました:
- エンドユーザーが内部 IPC コマンドを直接実行可能
- LLM API キー等の機密情報が DevTools の Network タブで盗聴可能
- リバースエンジニアリングが容易になる

## 修正内容

```diff
+[features]
+# devtools 機能 (WebView インスペクタ等) は dev 時のみ有効化。
+# release ビルドでは feature を渡さないため、エンドユーザーが内部 IPC を直接実行できない。
+# dev で有効化するには `tauri dev --features devtools` (apps/desktop/package.json の dev スクリプト参照)。
+devtools = ["tauri/devtools"]
+
[dependencies]
-tauri = { version = "2", features = ["devtools"] }
+tauri = "2"
```

```diff
// apps/desktop/package.json
-"dev": "npm run prepare-runtime && tauri dev",
+"dev": "npm run prepare-runtime && tauri dev --features devtools",
```

## 動作の変化

| 用途 | コマンド | devtools |
|------|---------|----------|
| 開発時 | `npm run dev:desktop` (内部で `npm run dev` → `tauri dev --features devtools`) | ✅ 有効 (従来通り) |
| 本番ビルド | `npm run build` (内部で `tauri build`、features 未指定) | ❌ 無効 (今回の修正対象) |
| CI リリースビルド | `tauri-action@v0` ([desktop-release.yml](.github/workflows/desktop-release.yml)) | ❌ 無効 (自動的に) |

CI 設定変更不要 — `tauri-action` は `tauri build` を呼ぶだけのため、features 未指定で
自動的に devtools 無しビルドになります。

## 検証

- [x] `cd apps/desktop/src-tauri && cargo check` (no features) 成功 (52秒, dev profile clean compile)
- [x] `lib.rs` 内に `open_devtools()` 等の直接呼び出しなし → 機能除外しても動作影響なし
- [ ] (このPR merge後) ローカルで `npm run dev:desktop` 起動 → DevTools 開けることを確認
- [ ] (このPR merge後) `npm run build` で .app 生成 → release .app で DevTools 開けないことを確認

## ロールバック

revert で完全復元可能。Cargo.toml を 1 行戻し、package.json を 1 行戻すだけ。

## 関連

- 検証で発見された 7件 Issue のうち #3 を修正
- PR #161 (macOS Updater)、PR #162 (バージョン統一) と独立