### PR TITLE
fix: Sidecar の orphan process 化を防止 (parent process 監視) (Issue #7)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -237,6 +237,9 @@ pub fn run() {
             );
 
             // Spawn the Bun server sidecar
+            // Pass our PID so the sidecar can self-terminate if we die ungracefully
+            // (SIGKILL, panic, etc.) — see apps/server-ts/src/index.ts parent-monitor.
+            let parent_pid = std::process::id();
             let shell = handle.shell();
             let (mut rx, child) = shell
                 .sidecar("server")
@@ -249,6 +252,7 @@ pub fn run() {
                 .env("UPLOAD_DIR", upload_dir.to_string_lossy().to_string())
                 .env("ANIMATIONS_DIR", animations_dir.to_string_lossy().to_string())
                 .env("AUDIO_DIR", audio_dir.to_string_lossy().to_string())
+                .env("AITUBERFLOW_PARENT_PID", parent_pid.to_string())
                 .spawn()
                 .expect("failed to spawn sidecar");
             drop(reservation);

--- a/apps/server-ts/src/index.ts
+++ b/apps/server-ts/src/index.ts
@@ -121,6 +121,26 @@ process.on("SIGINT", () => {
   process.exit(0);
 });
 
+// Parent process monitoring: prevents orphan sidecar when the desktop main
+// process is SIGKILLed, panics, or otherwise terminates without firing the
+// Tauri WindowEvent::Destroyed handler. macOS lacks Linux's PR_SET_PDEATHSIG,
+// so we poll explicitly. The Tauri side passes its PID via env var.
+const parentPidEnv = process.env.AITUBERFLOW_PARENT_PID;
+if (parentPidEnv) {
+  const parentPid = Number(parentPidEnv);
+  if (Number.isFinite(parentPid) && parentPid > 0) {
+    console.log(`[parent-monitor] watching parent PID ${parentPid}`);
+    setInterval(() => {
+      try {
+        process.kill(parentPid, 0);
+      } catch {
+        console.log(`[parent-monitor] parent PID ${parentPid} no longer alive, exiting sidecar`);
+        process.exit(0);
+      }
+    }, 1000).unref();
+  }
+}
+
 // Use export default for Bun's built-in server management.
 // This ensures --hot mode works correctly (handler replacement without restart).
 export default {


### PR DESCRIPTION
## 概要

検証中に SIGKILL でデスクトップ main プロセスを強制終了した際、Bun sidecar
プロセスが orphan 化 (PPID=1 launchd) して残存する問題を発見、修正します。

## 問題

これまでの実装 (apps/desktop/src-tauri/src/lib.rs):

```rust
.on_window_event(|window, event| {
    if window.label() == "main" && matches!(event, tauri::WindowEvent::Destroyed) {
        let state = window.state::<ServerProcess>();
        let mut guard = state.0.lock().unwrap();
        if let Some(child) = guard.take() {
            let _ = child.kill();
        }
    }
})
```

- 正常終了 (ユーザーがウィンドウを閉じる) では機能 ✅
- **SIGKILL / Rust panic / OOM などの異常終了では event handler が走らない** ❌
- macOS には Linux の `prctl(PR_SET_PDEATHSIG)` 相当機構が無いため、
  親プロセス死亡時に子プロセスへ自動通知できない

## 実機検証結果

```
$ ps -p 5633,14247 -o pid,ppid,stat,command
  PID  PPID STAT COMMAND
 5633  5412 S    target/debug/aituber-flow              # main
14247  5633 S    target/debug/server                    # sidecar (親=main)

$ kill -9 5633

$ ps -p 14247 -o pid,ppid,stat,command
  PID  PPID STAT COMMAND
14247     1 S    target/debug/server                    # ⚠️ PPID=1 (launchd) = orphan!
```

ユーザーが Force Quit / Activity Monitor 強制終了 / アプリクラッシュする度に
sidecar leak、port/DB ロック保持、メモリリーク発生。

## 修正内容

### apps/desktop/src-tauri/src/lib.rs

```diff
+ // Pass our PID so the sidecar can self-terminate if we die ungracefully
+ // (SIGKILL, panic, etc.) — see apps/server-ts/src/index.ts parent-monitor.
+ let parent_pid = std::process::id();
let shell = handle.shell();
let (mut rx, child) = shell
    .sidecar("server")
    ...
    .env("AUDIO_DIR", audio_dir.to_string_lossy().to_string())
+   .env("AITUBERFLOW_PARENT_PID", parent_pid.to_string())
    .spawn()
```

### apps/server-ts/src/index.ts

```typescript
// Parent process monitoring: prevents orphan sidecar when the desktop main
// process is SIGKILLed, panics, or otherwise terminates without firing the
// Tauri WindowEvent::Destroyed handler. macOS lacks Linux's PR_SET_PDEATHSIG,
// so we poll explicitly. The Tauri side passes its PID via env var.
const parentPidEnv = process.env.AITUBERFLOW_PARENT_PID;
if (parentPidEnv) {
  const parentPid = Number(parentPidEnv);
  if (Number.isFinite(parentPid) && parentPid > 0) {
    console.log(`[parent-monitor] watching parent PID ${parentPid}`);
    setInterval(() => {
      try {
        process.kill(parentPid, 0); // signal 0 = existence check only
      } catch {
        console.log(`[parent-monitor] parent PID ${parentPid} no longer alive, exiting sidecar`);
        process.exit(0);
      }
    }, 1000).unref();
  }
}
```

## 動作

| 終了方法 | 既存 cleanup (WindowEvent) | 新 cleanup (parent monitor) |
|---------|---------------------------|-----------------------------|
| ウィンドウ閉じる | ✅ 即時 | (走らない、必要なし) |
| アプリ終了メニュー | ✅ 即時 | (走らない、必要なし) |
| Force Quit | ❌ 走らず (orphan) | ✅ **最大1秒以内 (平均0.5秒)** |
| SIGKILL | ❌ 走らず (orphan) | ✅ **最大1秒以内** |
| Rust panic | ❌ 走らず (orphan) | ✅ **最大1秒以内** |

## 検証

- [x] `cargo check` (apps/desktop/src-tauri) 成功 (7.85s, dev profile clean compile)
- [x] 親監視ロジックを isolated test で検証 (non-existent PID 999999 → 1002ms で exit 確認)
- [ ] (このPR merge後の手動 E2E)
  - [ ] `npm run dev:desktop` → ps で sidecar の PPID=main 確認
  - [ ] `kill -9 <main_pid>` → 1秒以内に sidecar も終了することを確認
  - [ ] 通常終了 (ウィンドウ閉じ) も従来通り動作することを regression 確認

## 副次影響

- パフォーマンス: 1秒ごと `kill(pid, 0)` syscall 1回 = 無視できるレベル
- 既存の正常終了経路 (WindowEvent::Destroyed) は変更なし、両経路で cleanup
- `AITUBERFLOW_PARENT_PID` env が未設定 (sidecar を直接 bun run で起動した場合等) なら
  従来通り、stand-alone server モード互換

## ロールバック

revert で完全復元可能。データ・成果物への影響なし。

## 関連

- 検証で発見された 7件の Issue のうち #7 を修正
- PR #161 (macOS Updater)、#162 (バージョン統一)、#163 (devtools cfg) と独立