### PR TITLE
docs: add download stats chart to README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -22,6 +22,12 @@
   <a href="README.md">日本語</a>
 </p>
 
+<p align="center">
+  <a href="https://aituber-flow.dev/en/download">
+    <img src="https://aituber-flow.dev/download-stats.svg" alt="AITuberFlow downloads by platform" width="760">
+  </a>
+</p>
+
 ---
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@
   <a href="README.en.md">English</a>
 </p>
 
+<p align="center">
+  <a href="https://aituber-flow.dev/download">
+    <img src="https://aituber-flow.dev/download-stats.svg" alt="AITuberFlow downloads by platform" width="760">
+  </a>
+</p>
+
 ---
 
 ## 概要


### PR DESCRIPTION
## Summary
- Embed the public AITuberFlow download stats SVG near the top of the Japanese and English READMEs
- Link the chart to the corresponding download page

## Dependency
- This expects the website PR to publish https://aituber-flow.dev/download-stats.svg:
  https://github.com/oboroge0/aituber-flow.dev/pull/1

## Test Plan
- git diff --check
