### PR TITLE
fix: resolve all Biome lint errors

### DIFF
--- a/apps/server-ts/src/engine/event-bus.ts
+++ b/apps/server-ts/src/engine/event-bus.ts
@@ -200,14 +200,25 @@ export class EventFilter {
   /**
    * Safely resolve a dot-separated property path on an object.
    */
-  private _resolvePath(obj: Record<string, unknown>, path: string): unknown {
+  private _resolvePath(
+    obj: Record<string, unknown>,
+    path: string,
+  ): string | number | boolean | null {
     const parts = path.split(".");
     let current: unknown = obj;
     for (const part of parts) {
       if (current == null || typeof current !== "object") return null;
       current = (current as Record<string, unknown>)[part];
     }
-    return current ?? null;
+    if (current == null) return null;
+    if (
+      typeof current === "string" ||
+      typeof current === "number" ||
+      typeof current === "boolean"
+    ) {
+      return current;
+    }
+    return null;
   }
 }
 

--- a/apps/server-ts/src/engine/event-bus.ts
+++ b/apps/server-ts/src/engine/event-bus.ts
@@ -200,12 +200,12 @@ export class EventFilter {
   /**
    * Safely resolve a dot-separated property path on an object.
    */
-  private _resolvePath(obj: Record<string, any>, path: string): any {
+  private _resolvePath(obj: Record<string, unknown>, path: string): unknown {
     const parts = path.split(".");
-    let current: any = obj;
+    let current: unknown = obj;
     for (const part of parts) {
       if (current == null || typeof current !== "object") return null;
-      current = current[part];
+      current = (current as Record<string, unknown>)[part];
     }
     return current ?? null;
   }

--- a/apps/server-ts/src/engine/executor.ts
+++ b/apps/server-ts/src/engine/executor.ts
@@ -90,6 +90,7 @@ export class NodeContext {
 
     let evt: Event;
     if ("type" in event && typeof event.type === "string") {
+      // biome-ignore lint/suspicious/noExplicitAny: plugin event may be loosely typed
       const { type, source_node_id, sourceNodeId, timestamp, ...payload } = event as any;
       evt = {
         type,
@@ -146,12 +147,13 @@ export class NodeContext {
     return controller;
   }
 
-  async updateCharacter(updates: Record<string, any>): Promise<void> {
+  // biome-ignore lint/suspicious/noExplicitAny: plugin API boundary — character state is dynamic
+  async updateCharacter(updates: Record<string, unknown>): Promise<void> {
     // Guard against prototype pollution: never copy __proto__/constructor/prototype
     // keys from user-controllable updates into the character state.
     for (const [key, value] of Object.entries(updates)) {
       if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
-      this.character[key] = value;
+      (this.character as Record<string, unknown>)[key] = value;
     }
   }
 
@@ -163,6 +165,7 @@ export class NodeContext {
     return (this.character.personality as string) ?? "";
   }
 
+  // biome-ignore lint/suspicious/noExplicitAny: emotion shape defined by plugin
   getEmotion(): Record<string, any> {
     return (
       (this.character.emotion as Record<string, any>) ?? {
@@ -190,8 +193,10 @@ export class NodeContext {
 interface NodeRuntime {
   nodeId: string;
   nodeType: string;
+  // biome-ignore lint/suspicious/noExplicitAny: plugin config is dynamic
   config: Record<string, any>;
-  instance: any | null;
+  // biome-ignore lint/suspicious/noExplicitAny: plugin instance shape is unknown at compile time
+  instance: unknown | null;
   context: NodeContext;
 }
 
@@ -374,7 +379,7 @@ export class WorkflowExecutor {
   private async initializeNodes(
     workflowId: string,
     nodes: NodeData[],
-    character: Record<string, any>,
+    character: Record<string, unknown>,
     settings: Record<string, string>,
   ): Promise<void> {
     const runtimes = new Map<string, NodeRuntime>();
@@ -457,7 +462,7 @@ export class WorkflowExecutor {
       await this.workflowLocks.get(workflowId);
     }
 
-    let resolve: () => void;
+    let resolve: (() => void) | undefined;
     const lock = new Promise<void>((r) => {
       resolve = r;
     });
@@ -467,7 +472,7 @@ export class WorkflowExecutor {
       return await fn();
     } finally {
       this.workflowLocks.delete(workflowId);
-      resolve!();
+      resolve?.();
     }
   }
 

--- a/apps/server-ts/src/engine/executor.ts
+++ b/apps/server-ts/src/engine/executor.ts
@@ -196,7 +196,7 @@ interface NodeRuntime {
   // biome-ignore lint/suspicious/noExplicitAny: plugin config is dynamic
   config: Record<string, any>;
   // biome-ignore lint/suspicious/noExplicitAny: plugin instance shape is unknown at compile time
-  instance: unknown | null;
+  instance: unknown;
   context: NodeContext;
 }
 
@@ -419,7 +419,9 @@ export class WorkflowExecutor {
     inputs: Record<string, any>,
   ): Promise<Record<string, any>> {
     if (runtime.instance) {
-      return await runtime.instance.execute(inputs, runtime.context);
+      // biome-ignore lint/suspicious/noExplicitAny: plugin instance shape defined at runtime
+      const inst = runtime.instance as Record<string, any>;
+      return await inst.execute(inputs, runtime.context);
     }
     return await this.executeBuiltinNode(runtime.nodeType, runtime.config, inputs, runtime.context);
   }
@@ -430,9 +432,11 @@ export class WorkflowExecutor {
     this.nodeInstances.delete(workflowId);
 
     for (const runtime of runtimes.values()) {
-      if (runtime.instance?.teardown) {
+      // biome-ignore lint/suspicious/noExplicitAny: plugin instance shape defined at runtime
+      const inst = runtime.instance as Record<string, any> | null;
+      if (inst?.teardown) {
         try {
-          await runtime.instance.teardown();
+          await inst.teardown();
         } catch (err) {
           console.error(`Error tearing down node ${runtime.nodeId}:`, err);
         }

--- a/apps/server-ts/src/engine/validator.ts
+++ b/apps/server-ts/src/engine/validator.ts
@@ -12,7 +12,7 @@
 import { join } from "node:path";
 import { db } from "../db/database";
 import { globalSettings } from "../db/schema";
-import { getPluginsDir, SOURCE_NODE_TYPES } from "./plugin-loader";
+import { SOURCE_NODE_TYPES, getPluginsDir } from "./plugin-loader";
 
 // ─── Types ───────────────────────────────────────────────────────
 
@@ -92,7 +92,7 @@ const manifestCache = new Map<string, PluginManifest | null>();
 
 async function loadManifest(nodeType: string): Promise<PluginManifest | null> {
   if (manifestCache.has(nodeType)) {
-    return manifestCache.get(nodeType)!;
+    return manifestCache.get(nodeType) ?? null;
   }
 
   const pluginsDir = getPluginsDir();
@@ -156,8 +156,7 @@ function checkRequiredConfigCore(
       if (!fieldDef.required) continue;
 
       const value = node.config?.[key];
-      const isEmpty =
-        value === undefined || value === null || value === "";
+      const isEmpty = value === undefined || value === null || value === "";
 
       if (isEmpty) {
         // Skip if a global setting provides this value
@@ -248,7 +247,8 @@ function checkUnreachableNodes(
     const fromId = conn.from.nodeId;
     const toId = conn.to.nodeId;
     if (adjacency.has(fromId)) {
-      const neighbors = adjacency.get(fromId)!;
+      const neighbors = adjacency.get(fromId) ?? [];
+      adjacency.set(fromId, neighbors);
       if (!neighbors.includes(toId)) {
         neighbors.push(toId);
       }
@@ -257,9 +257,7 @@ function checkUnreachableNodes(
 
   // Find entry points
   const startNodes = nodes.filter((n) => n.type === "start").map((n) => n.id);
-  const sourceNodes = nodes
-    .filter((n) => SOURCE_NODE_TYPES.has(n.type))
-    .map((n) => n.id);
+  const sourceNodes = nodes.filter((n) => SOURCE_NODE_TYPES.has(n.type)).map((n) => n.id);
 
   let entryPoints: string[];
 
@@ -276,9 +274,7 @@ function checkUnreachableNodes(
         incomingCount.set(conn.to.nodeId, (incomingCount.get(conn.to.nodeId) ?? 0) + 1);
       }
     }
-    entryPoints = [...incomingCount.entries()]
-      .filter(([, count]) => count === 0)
-      .map(([id]) => id);
+    entryPoints = [...incomingCount.entries()].filter(([, count]) => count === 0).map(([id]) => id);
   }
 
   if (entryPoints.length === 0) {
@@ -298,7 +294,8 @@ function checkUnreachableNodes(
   const reachable = new Set<string>();
   const queue = [...entryPoints];
   while (queue.length > 0) {
-    const nodeId = queue.shift()!;
+    const nodeId = queue.shift();
+    if (!nodeId) break;
     if (reachable.has(nodeId)) continue;
     reachable.add(nodeId);
     for (const neighbor of adjacency.get(nodeId) ?? []) {
@@ -341,7 +338,8 @@ function checkCircularReferences(
     const fromId = conn.from.nodeId;
     const toId = conn.to.nodeId;
     if (adjacency.has(fromId)) {
-      const neighbors = adjacency.get(fromId)!;
+      const neighbors = adjacency.get(fromId) ?? [];
+      adjacency.set(fromId, neighbors);
       if (!neighbors.includes(toId)) {
         neighbors.push(toId);
       }
@@ -406,10 +404,7 @@ function checkCircularReferences(
 /**
  * Check API key settings on LLM/TTS nodes, considering global settings fallback.
  */
-function checkApiKeys(
-  nodes: NodeData[],
-  settings: Record<string, string>,
-): ValidationIssue[] {
+function checkApiKeys(nodes: NodeData[], settings: Record<string, string>): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
   for (const node of nodes) {
@@ -421,17 +416,15 @@ function checkApiKeys(
     const nodeApiKey = node.config?.apiKey;
     const globalApiKey = settings[mapping.apiKey];
 
-    const nodeKeyEmpty =
-      nodeApiKey === undefined || nodeApiKey === null || nodeApiKey === "";
-    const globalKeyEmpty =
-      !globalApiKey || globalApiKey === "";
+    const nodeKeyEmpty = nodeApiKey === undefined || nodeApiKey === null || nodeApiKey === "";
+    const globalKeyEmpty = !globalApiKey || globalApiKey === "";
 
     if (nodeKeyEmpty && globalKeyEmpty) {
       issues.push({
         nodeId: node.id,
         nodeName: node.type,
         level: "warning",
-        message: `APIキーが設定されていません（ノード設定またはグローバル設定で設定してください）`,
+        message: "APIキーが設定されていません（ノード設定またはグローバル設定で設定してください）",
       });
     }
   }
@@ -444,9 +437,7 @@ function checkApiKeys(
 /**
  * Validate a workflow and return all issues found.
  */
-export async function validateWorkflow(
-  workflowData: WorkflowData,
-): Promise<ValidationIssue[]> {
+export async function validateWorkflow(workflowData: WorkflowData): Promise<ValidationIssue[]> {
   const { nodes, connections } = workflowData;
 
   if (!nodes || nodes.length === 0) {

--- a/apps/server-ts/src/index.ts
+++ b/apps/server-ts/src/index.ts
@@ -16,6 +16,7 @@ import { setExecutor, setWSBroadcaster, workflowRoutes } from "./routes/workflow
 import { createWebSocketHandler, setExecutorForWS, wsBroadcaster } from "./websocket/handler";
 
 const app = new Hono();
+// biome-ignore lint/suspicious/noExplicitAny: Bun ServerWebSocket requires any as data type parameter
 const { upgradeWebSocket, websocket } = createBunWebSocket<ServerWebSocket<any>>();
 
 // Static file serving directory (set by Tauri for desktop mode)
@@ -67,7 +68,9 @@ app.get(
 // When STATIC_DIR is set, serve the Next.js static export and provide SPA fallback
 if (STATIC_DIR) {
   const indexExists = existsSync(join(STATIC_DIR, "index.html"));
-  console.log(`[static] STATIC_DIR=${STATIC_DIR} index.html=${indexExists ? "found" : "NOT FOUND"}`);
+  console.log(
+    `[static] STATIC_DIR=${STATIC_DIR} index.html=${indexExists ? "found" : "NOT FOUND"}`,
+  );
 
   // Normalize path separators for cross-platform compatibility (Hono serveStatic)
   const normalizedStaticDir = STATIC_DIR.replace(/\\/g, "/");

--- a/apps/server-ts/src/integrations/vtube-studio.ts
+++ b/apps/server-ts/src/integrations/vtube-studio.ts
@@ -189,6 +189,7 @@ class VTubeStudioClient {
           pluginDeveloper: PLUGIN_DEVELOPER,
         },
         60_000,
+        // biome-ignore lint/suspicious/noExplicitAny: VTube Studio API response shape is dynamic
       )) as Record<string, any> | null;
 
       return response?.data?.authenticationToken ?? null;
@@ -204,6 +205,7 @@ class VTubeStudioClient {
         pluginName: PLUGIN_NAME,
         pluginDeveloper: PLUGIN_DEVELOPER,
         authenticationToken: token,
+        // biome-ignore lint/suspicious/noExplicitAny: VTube Studio API response shape is dynamic
       })) as Record<string, any> | null;
 
       if (response?.data) {

--- a/apps/server-ts/src/routes/settings.ts
+++ b/apps/server-ts/src/routes/settings.ts
@@ -35,8 +35,7 @@ app.put("/", zValidator("json", updateSettingsBody), async (c) => {
 
   _db.transaction((tx) => {
     for (const [key, value] of Object.entries(body)) {
-      tx
-        .insert(globalSettings)
+      tx.insert(globalSettings)
         .values({ key, value, updatedAt: now })
         .onConflictDoUpdate({
           target: globalSettings.key,

--- a/apps/server-ts/src/routes/workflows.ts
+++ b/apps/server-ts/src/routes/workflows.ts
@@ -150,7 +150,7 @@ app.get("/:id", async (c) => {
 // Update workflow
 app.put("/:id", async (c) => {
   const id = c.req.param("id");
-  let body: unknown;
+  let body: Record<string, unknown>;
   try {
     body = await c.req.json();
   } catch {
@@ -161,8 +161,9 @@ app.put("/:id", async (c) => {
   if (!existing) return c.json({ detail: "Workflow not found" }, 404);
 
   const updates: Partial<WorkflowRow> = { updatedAt: nowISO() };
-  if (body.name !== undefined) updates.name = body.name;
-  if (body.description !== undefined) updates.description = body.description;
+  if (typeof body.name === "string") updates.name = body.name;
+  if (body.description === null || typeof body.description === "string")
+    updates.description = body.description ?? null;
   if (body.nodes !== undefined) updates.nodesJson = JSON.stringify(body.nodes);
   if (body.connections !== undefined) updates.connectionsJson = JSON.stringify(body.connections);
   if (body.character !== undefined) updates.characterJson = JSON.stringify(body.character);

--- a/apps/server-ts/src/routes/workflows.ts
+++ b/apps/server-ts/src/routes/workflows.ts
@@ -150,7 +150,7 @@ app.get("/:id", async (c) => {
 // Update workflow
 app.put("/:id", async (c) => {
   const id = c.req.param("id");
-  let body;
+  let body: unknown;
   try {
     body = await c.req.json();
   } catch {
@@ -240,7 +240,7 @@ const importWorkflowBody = z.object({
 });
 
 app.post("/import", async (c) => {
-  let raw;
+  let raw: unknown;
   try {
     raw = await c.req.json();
   } catch {
@@ -342,8 +342,7 @@ app.post("/:id/start", async (c) => {
 
   const nodes = (body.nodes as unknown[] | undefined) ?? JSON.parse(existing.nodesJson || "[]");
   const connections =
-    (body.connections as unknown[] | undefined) ??
-    JSON.parse(existing.connectionsJson || "[]");
+    (body.connections as unknown[] | undefined) ?? JSON.parse(existing.connectionsJson || "[]");
   const character =
     (body.character as Record<string, unknown> | undefined) ??
     JSON.parse(existing.characterJson || "{}");

--- a/apps/server-ts/src/websocket/handler.ts
+++ b/apps/server-ts/src/websocket/handler.ts
@@ -17,10 +17,13 @@ interface WSMessage {
   payload?: Record<string, unknown>;
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: Bun ServerWebSocket requires any as data type parameter
+type BunWS = ServerWebSocket<any>;
+
 interface ClientInfo {
   id: string;
   rooms: Set<string>;
-  ws: WSContext<ServerWebSocket<any>>;
+  ws: WSContext<BunWS>;
 }
 
 /** Maximum allowed WebSocket message size (1 MB). */
@@ -33,13 +36,13 @@ export class WSBroadcaster {
   private rooms = new Map<string, Set<string>>(); // room -> client ids
   // Use ws.raw (ServerWebSocket) as key instead of WSContext,
   // because Hono creates a new WSContext wrapper per event.
-  private wsClientIds = new WeakMap<ServerWebSocket<any>, string>();
+  private wsClientIds = new WeakMap<BunWS, string>();
 
-  private getRaw(ws: WSContext<ServerWebSocket<any>>): ServerWebSocket<any> {
-    return (ws as any).raw;
+  private getRaw(ws: WSContext<BunWS>): BunWS {
+    return (ws as WSContext<BunWS> & { raw: BunWS }).raw;
   }
 
-  addClient(id: string, ws: WSContext<ServerWebSocket<any>>): void {
+  addClient(id: string, ws: WSContext<BunWS>): void {
     this.clients.set(id, { id, rooms: new Set(), ws });
     this.wsClientIds.set(this.getRaw(ws), id);
   }
@@ -55,7 +58,7 @@ export class WSBroadcaster {
     this.clients.delete(id);
   }
 
-  getClientId(ws: WSContext<ServerWebSocket<any>>): string | undefined {
+  getClientId(ws: WSContext<BunWS>): string | undefined {
     return this.wsClientIds.get(this.getRaw(ws));
   }
 
@@ -190,9 +193,7 @@ let clientCounter = 0;
 function parseMessageData(data: WSMessageReceive): WSMessage {
   if (typeof data === "string") {
     if (data.length > MAX_WS_MESSAGE_SIZE) {
-      throw new Error(
-        `Message too large: ${data.length} bytes (max: ${MAX_WS_MESSAGE_SIZE})`,
-      );
+      throw new Error(`Message too large: ${data.length} bytes (max: ${MAX_WS_MESSAGE_SIZE})`);
     }
     return JSON.parse(data) as WSMessage;
   }
@@ -203,22 +204,20 @@ function parseMessageData(data: WSMessageReceive): WSMessage {
 
   const bytes = new Uint8Array(data);
   if (bytes.byteLength > MAX_WS_MESSAGE_SIZE) {
-    throw new Error(
-      `Message too large: ${bytes.byteLength} bytes (max: ${MAX_WS_MESSAGE_SIZE})`,
-    );
+    throw new Error(`Message too large: ${bytes.byteLength} bytes (max: ${MAX_WS_MESSAGE_SIZE})`);
   }
   return JSON.parse(new TextDecoder().decode(bytes)) as WSMessage;
 }
 
-export function createWebSocketHandler(): WSEvents<ServerWebSocket<any>> {
+export function createWebSocketHandler(): WSEvents<BunWS> {
   return {
-    onOpen(_evt: Event, ws: WSContext<ServerWebSocket<any>>) {
+    onOpen(_evt: Event, ws: WSContext<BunWS>) {
       const clientId = `client_${++clientCounter}`;
       wsBroadcaster.addClient(clientId, ws);
       console.log(`WebSocket client connected: ${clientId}`);
     },
 
-    onMessage(evt: MessageEvent<WSMessageReceive>, ws: WSContext<ServerWebSocket<any>>) {
+    onMessage(evt: MessageEvent<WSMessageReceive>, ws: WSContext<BunWS>) {
       const clientId = wsBroadcaster.getClientId(ws);
       if (!clientId) return;
 
@@ -309,7 +308,7 @@ export function createWebSocketHandler(): WSEvents<ServerWebSocket<any>> {
       }
     },
 
-    onClose(_evt: CloseEvent, ws: WSContext<ServerWebSocket<any>>) {
+    onClose(_evt: CloseEvent, ws: WSContext<BunWS>) {
       const clientId = wsBroadcaster.getClientId(ws);
       if (clientId) {
         wsBroadcaster.removeClient(clientId);
@@ -317,7 +316,7 @@ export function createWebSocketHandler(): WSEvents<ServerWebSocket<any>> {
       }
     },
 
-    onError(evt: Event, ws: WSContext<ServerWebSocket<any>>) {
+    onError(evt: Event, ws: WSContext<BunWS>) {
       const clientId = wsBroadcaster.getClientId(ws);
       console.error(`WebSocket error for ${clientId}:`, evt);
     },


### PR DESCRIPTION
## 概要

CI に Biome lint を追加したことで、既存コードの問題が検出されたため修正。

## 変更内容

**エラー修正（0 errors に到達）**
- `noNonNullAssertion`: `!` を `?.` / `?? null` / guard check に置換
- `noImplicitAnyLet`: `let body` / `let raw` を `unknown` で明示
- `noUnusedTemplateLiteral`: 不要なテンプレートリテラルを文字列リテラルに変換
- formatter: settings.ts インデント、vtube-studio.ts フォーマット修正
- import sort: validator.ts import 順序を修正

**意図的な `biome-ignore`（構造的 any）**
- `ServerWebSocket<any>`: Bun の型制約で any 必須
- VTube Studio API レスポンス: 動的シェイプ
- executor.ts の plugin dispatch: プラグイン API 境界

## Biome 結果
```
Checked 19 files. Found 0 errors, 25 warnings.
```
warnings はすべて plugin/API 境界の `noExplicitAny` (warn レベル)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved type safety and runtime safety across server logic, reducing chances of unexpected runtime issues.
  * More robust request and workflow handling with stricter input checks.
  * Hardened WebSocket client handling and connection cleanup for more reliable realtime behavior.
  * Minor formatting and lint-suppression cleanups to improve maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oboroge0/AITuberFlow/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->