### PR TITLE
feat: 右クリックメニューをカテゴリ別サブメニュー形式に改善

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aituber-flow/desktop",
-  "version": "2.3.2",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aituber-flow/desktop",
-      "version": "2.3.2",
+      "version": "2.3.1",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/web/components/editor/Canvas.tsx
+++ b/apps/web/components/editor/Canvas.tsx
@@ -27,7 +27,8 @@ import FieldSelectorNode from './FieldSelectorNode';
 import ContextMenu, { type ContextMenuItem } from './ContextMenu';
 import DataPreviewPopup from './DataPreviewPopup';
 import SearchPanel from './SearchPanel';
-import { getNodeTypes, type SidebarNodeType } from './Sidebar';
+import { getNodeTypes, type SidebarNodeType, CATEGORY_COLORS, CATEGORY_LABELS } from './Sidebar';
+import { type PluginCategory } from '@/lib/types';
 import { type PortType, type PortDefinition } from '@/lib/portTypes';
 import { useUIPreferencesStore, type NodeDisplayMode } from '@/stores/uiPreferencesStore';
 import { type PromptSection } from '@/components/panels/NodeSettings';
@@ -620,25 +621,58 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
       ];
     }
 
-    // Pane context menu - add nodes (dynamically loaded from plugins)
+    // Pane context menu — "Add Node ▶" with category flyout submenu
     const nodeTypesList = getNodeTypes();
-    return nodeTypesList.map((nodeType) => ({
-      label: `Add ${nodeType.label}`,
-      icon: <span style={{ color: nodeType.color }}>{nodeType.icon}</span>,
-      onClick: () => {
-        const reactFlowBounds = reactFlowWrapper.current?.getBoundingClientRect();
-        if (!reactFlowBounds) return;
+    const { plugins } = usePluginStore.getState();
 
-        addNode({
-          type: nodeType.id,
-          position: {
-            x: contextMenu.x - reactFlowBounds.left - 80,
-            y: contextMenu.y - reactFlowBounds.top - 30,
+    // Group node types by category
+    const byCategory: Record<string, SidebarNodeType[]> = {};
+    for (const nt of nodeTypesList) {
+      const plugin = plugins.find((p) => p.id === nt.id);
+      const cat = plugin?.category ?? 'utility';
+      if (!byCategory[cat]) byCategory[cat] = [];
+      byCategory[cat].push(nt);
+    }
+
+    const categoryOrder: PluginCategory[] = [
+      'control', 'input', 'llm', 'tts', 'avatar', 'output', 'utility', 'obs',
+    ];
+
+    const submenuSections = categoryOrder
+      .filter((cat) => byCategory[cat]?.length > 0)
+      .map((cat) => ({
+        categoryId: cat,
+        label: CATEGORY_LABELS[cat] ?? cat,
+        color: CATEGORY_COLORS[cat] ?? '#6B7280',
+        items: (byCategory[cat] ?? []).map((nodeType) => ({
+          label: nodeType.label,
+          icon: <span style={{ color: nodeType.color }}>{nodeType.icon}</span>,
+          onClick: () => {
+            const reactFlowBounds = reactFlowWrapper.current?.getBoundingClientRect();
+            if (!reactFlowBounds) return;
+            addNode({
+              type: nodeType.id,
+              position: {
+                x: contextMenu.x - reactFlowBounds.left - 80,
+                y: contextMenu.y - reactFlowBounds.top - 30,
+              },
+              config: { ...nodeType.defaultConfig },
+            });
           },
-          config: { ...nodeType.defaultConfig },
-        });
+        })),
+      }));
+
+    return [
+      {
+        label: 'ノードを追加',
+        icon: (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="16" /><line x1="8" y1="12" x2="16" y2="12" />
+          </svg>
+        ),
+        submenuSections,
       },
-    }));
+    ];
   };
 
   return (

--- a/apps/web/components/editor/ContextMenu.tsx
+++ b/apps/web/components/editor/ContextMenu.tsx
@@ -1,14 +1,90 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+
+export interface ContextMenuSubmenuItem {
+  label: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+}
+
+export interface ContextMenuSubmenuSection {
+  categoryId: string;
+  label: string;
+  color?: string;
+  items: ContextMenuSubmenuItem[];
+}
 
 export interface ContextMenuItem {
   label: string;
   icon?: React.ReactNode;
-  onClick: () => void;
+  onClick?: () => void;
   danger?: boolean;
   divider?: boolean;
   shortcut?: string;
+  submenuSections?: ContextMenuSubmenuSection[];
+}
+
+// Flyout submenu shown on hover
+function SubMenu({
+  sections,
+  parentRect,
+  onClose,
+}: {
+  sections: ContextMenuSubmenuSection[];
+  parentRect: DOMRect;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Position to the right of parent item; flip left if near viewport edge
+  const spaceRight = window.innerWidth - parentRect.right;
+  const left = spaceRight > 208 ? parentRect.right + 4 : parentRect.left - 208;
+  const top = Math.min(parentRect.top, window.innerHeight - 420);
+
+  return (
+    <div
+      ref={menuRef}
+      className="fixed z-[60] py-1 rounded-lg shadow-xl overflow-y-auto"
+      style={{
+        left,
+        top,
+        maxHeight: '420px',
+        background: 'rgba(17, 24, 39, 0.98)',
+        border: '1px solid rgba(255,255,255,0.1)',
+        minWidth: '200px',
+      }}
+    >
+      {sections.map((section, si) => (
+        <React.Fragment key={section.categoryId}>
+          {si > 0 && <div className="my-1 border-t border-white/10" />}
+          <div
+            className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider"
+            style={{ color: section.color ?? 'rgba(255,255,255,0.35)' }}
+          >
+            {section.label}
+          </div>
+          {section.items.map((item, ii) => (
+            <button
+              key={ii}
+              onClick={() => {
+                item.onClick();
+                onClose();
+              }}
+              className="w-full px-3 py-1.5 text-left text-sm flex items-center gap-2 text-white/90 hover:bg-white/10 transition-colors"
+            >
+              {item.icon && (
+                <span className="w-4 h-4 flex-shrink-0 flex items-center justify-center">
+                  {item.icon}
+                </span>
+              )}
+              <span className="flex-1 truncate">{item.label}</span>
+            </button>
+          ))}
+        </React.Fragment>
+      ))}
+    </div>
+  );
 }
 
 interface ContextMenuProps {
@@ -20,6 +96,9 @@ interface ContextMenuProps {
 
 export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
+  const [activeSubmenuIndex, setActiveSubmenuIndex] = useState<number | null>(null);
+  const [submenuParentRect, setSubmenuParentRect] = useState<DOMRect | null>(null);
+  const clearTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -27,25 +106,33 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
         onClose();
       }
     };
-
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
+      if (e.key === 'Escape') onClose();
     };
-
     document.addEventListener('mousedown', handleClickOutside);
     document.addEventListener('keydown', handleEscape);
-
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleEscape);
     };
   }, [onClose]);
 
-  // Adjust position to keep menu in viewport
   const adjustedX = Math.min(x, window.innerWidth - 200);
-  const adjustedY = Math.min(y, window.innerHeight - items.length * 40);
+  const adjustedY = Math.min(y, window.innerHeight - items.length * 36 - 8);
+
+  const handleMouseEnter = (index: number, e: React.MouseEvent<HTMLButtonElement>) => {
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    if (items[index].submenuSections) {
+      setActiveSubmenuIndex(index);
+      setSubmenuParentRect(e.currentTarget.getBoundingClientRect());
+    } else {
+      // Small delay before hiding submenu so the mouse can move across without flicker
+      clearTimerRef.current = setTimeout(() => {
+        setActiveSubmenuIndex(null);
+        setSubmenuParentRect(null);
+      }, 80);
+    }
+  };
 
   return (
     <div
@@ -61,31 +148,43 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
     >
       {items.map((item, index) => (
         <React.Fragment key={index}>
-          {item.divider && (
-            <div className="my-1 border-t border-white/10" />
-          )}
+          {item.divider && <div className="my-1 border-t border-white/10" />}
           <button
+            onMouseEnter={(e) => handleMouseEnter(index, e)}
             onClick={() => {
-              item.onClick();
+              if (item.submenuSections) return; // submenu items opened on hover, not click
+              item.onClick?.();
               onClose();
             }}
             className={`
-              w-full px-3 py-2 text-left text-sm flex items-center gap-2
-              transition-colors
-              ${item.danger
-                ? 'text-red-400 hover:bg-red-500/20'
-                : 'text-white/90 hover:bg-white/10'
-              }
+              w-full px-3 py-2 text-left text-sm flex items-center gap-2 transition-colors
+              ${item.danger ? 'text-red-400 hover:bg-red-500/20' : 'text-white/90 hover:bg-white/10'}
+              ${activeSubmenuIndex === index ? 'bg-white/10' : ''}
             `}
           >
-            {item.icon && <span className="w-4 h-4">{item.icon}</span>}
+            {item.icon && <span className="w-4 h-4 flex items-center justify-center">{item.icon}</span>}
             <span className="flex-1">{item.label}</span>
+            {item.submenuSections && (
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-white/40 flex-shrink-0">
+                <polyline points="9 18 15 12 9 6" />
+              </svg>
+            )}
             {item.shortcut && (
               <span className="text-xs text-white/40">{item.shortcut}</span>
             )}
           </button>
         </React.Fragment>
       ))}
+
+      {activeSubmenuIndex !== null &&
+        submenuParentRect &&
+        items[activeSubmenuIndex]?.submenuSections && (
+          <SubMenu
+            sections={items[activeSubmenuIndex].submenuSections!}
+            parentRect={submenuParentRect}
+            onClose={onClose}
+          />
+        )}
     </div>
   );
 }

--- a/apps/web/components/editor/Sidebar.tsx
+++ b/apps/web/components/editor/Sidebar.tsx
@@ -27,7 +27,7 @@ interface SidebarProps {
 }
 
 // Category display colors (consistent with create_node.py)
-const CATEGORY_COLORS: Record<PluginCategory, string> = {
+export const CATEGORY_COLORS: Record<PluginCategory, string> = {
   control: '#10B981',
   input: '#22C55E',
   llm: '#10B981',
@@ -39,7 +39,7 @@ const CATEGORY_COLORS: Record<PluginCategory, string> = {
 };
 
 // Category labels
-const CATEGORY_LABELS: Record<PluginCategory, string> = {
+export const CATEGORY_LABELS: Record<PluginCategory, string> = {
   control: 'Control Flow',
   input: 'Input',
   llm: 'LLM',


### PR DESCRIPTION
## 概要
pane右クリック時にノードが30件フラット表示されていた問題を解消。

## 変更内容
- 「ノードを追加 ▶」1項目にまとめ、カーソルを乗せるとカテゴリ別フライアウトが開く
- カテゴリ: Control Flow / Input / LLM / TTS / Avatar / Output / Utility / OBS
- フライアウトはビューポート端で左右自動反転
- `ContextMenu.tsx` に `submenuSections` プロパティを追加（hover で表示、既存の onClick 動作と互換）
- `Sidebar.tsx` の `CATEGORY_COLORS` / `CATEGORY_LABELS` を export に変更

## Before / After
**Before:** 右クリック → 全30ノードがフラットに並ぶ
**After:** 右クリック →「ノードを追加 ▶」→ ホバーでカテゴリ別サブメニューが展開

## テスト
- `npm run build` 通過
- node / edge の右クリックメニュー（削除等）は従来通り動作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized the "Add Node" menu into categorized submenus grouped by node type for improved discoverability.
  * Added hover-based submenu navigation for faster node selection in the editor.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oboroge0/AITuberFlow/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->