### PR TITLE
fix: alert()/confirm()をtoast通知に統一 (#103)

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aituber-flow/desktop",
-  "version": "2.3.2",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aituber-flow/desktop",
-      "version": "2.3.2",
+      "version": "2.3.1",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/web/components/editor/Canvas.tsx
+++ b/apps/web/components/editor/Canvas.tsx
@@ -27,7 +27,8 @@ import FieldSelectorNode from './FieldSelectorNode';
 import ContextMenu, { type ContextMenuItem } from './ContextMenu';
 import DataPreviewPopup from './DataPreviewPopup';
 import SearchPanel from './SearchPanel';
-import { getNodeTypes, type SidebarNodeType } from './Sidebar';
+import { getNodeTypes, type SidebarNodeType, CATEGORY_COLORS, CATEGORY_LABELS } from './Sidebar';
+import { type PluginCategory } from '@/lib/types';
 import { type PortType, type PortDefinition } from '@/lib/portTypes';
 import { useUIPreferencesStore, type NodeDisplayMode } from '@/stores/uiPreferencesStore';
 import { type PromptSection } from '@/components/panels/NodeSettings';
@@ -620,25 +621,58 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
       ];
     }
 
-    // Pane context menu - add nodes (dynamically loaded from plugins)
+    // Pane context menu — "Add Node ▶" with category flyout submenu
     const nodeTypesList = getNodeTypes();
-    return nodeTypesList.map((nodeType) => ({
-      label: `Add ${nodeType.label}`,
-      icon: <span style={{ color: nodeType.color }}>{nodeType.icon}</span>,
-      onClick: () => {
-        const reactFlowBounds = reactFlowWrapper.current?.getBoundingClientRect();
-        if (!reactFlowBounds) return;
+    const { plugins } = usePluginStore.getState();
 
-        addNode({
-          type: nodeType.id,
-          position: {
-            x: contextMenu.x - reactFlowBounds.left - 80,
-            y: contextMenu.y - reactFlowBounds.top - 30,
+    // Group node types by category
+    const byCategory: Record<string, SidebarNodeType[]> = {};
+    for (const nt of nodeTypesList) {
+      const plugin = plugins.find((p) => p.id === nt.id);
+      const cat = plugin?.category ?? 'utility';
+      if (!byCategory[cat]) byCategory[cat] = [];
+      byCategory[cat].push(nt);
+    }
+
+    const categoryOrder: PluginCategory[] = [
+      'control', 'input', 'llm', 'tts', 'avatar', 'output', 'utility', 'obs',
+    ];
+
+    const submenuSections = categoryOrder
+      .filter((cat) => byCategory[cat]?.length > 0)
+      .map((cat) => ({
+        categoryId: cat,
+        label: CATEGORY_LABELS[cat] ?? cat,
+        color: CATEGORY_COLORS[cat] ?? '#6B7280',
+        items: (byCategory[cat] ?? []).map((nodeType) => ({
+          label: nodeType.label,
+          icon: <span style={{ color: nodeType.color }}>{nodeType.icon}</span>,
+          onClick: () => {
+            const reactFlowBounds = reactFlowWrapper.current?.getBoundingClientRect();
+            if (!reactFlowBounds) return;
+            addNode({
+              type: nodeType.id,
+              position: {
+                x: contextMenu.x - reactFlowBounds.left - 80,
+                y: contextMenu.y - reactFlowBounds.top - 30,
+              },
+              config: { ...nodeType.defaultConfig },
+            });
           },
-          config: { ...nodeType.defaultConfig },
-        });
+        })),
+      }));
+
+    return [
+      {
+        label: 'ノードを追加',
+        icon: (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="16" /><line x1="8" y1="12" x2="16" y2="12" />
+          </svg>
+        ),
+        submenuSections,
       },
-    }));
+    ];
   };
 
   return (

--- a/apps/web/components/editor/ContextMenu.tsx
+++ b/apps/web/components/editor/ContextMenu.tsx
@@ -1,14 +1,90 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+
+export interface ContextMenuSubmenuItem {
+  label: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+}
+
+export interface ContextMenuSubmenuSection {
+  categoryId: string;
+  label: string;
+  color?: string;
+  items: ContextMenuSubmenuItem[];
+}
 
 export interface ContextMenuItem {
   label: string;
   icon?: React.ReactNode;
-  onClick: () => void;
+  onClick?: () => void;
   danger?: boolean;
   divider?: boolean;
   shortcut?: string;
+  submenuSections?: ContextMenuSubmenuSection[];
+}
+
+// Flyout submenu shown on hover
+function SubMenu({
+  sections,
+  parentRect,
+  onClose,
+}: {
+  sections: ContextMenuSubmenuSection[];
+  parentRect: DOMRect;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Position to the right of parent item; flip left if near viewport edge
+  const spaceRight = window.innerWidth - parentRect.right;
+  const left = spaceRight > 208 ? parentRect.right + 4 : parentRect.left - 208;
+  const top = Math.min(parentRect.top, window.innerHeight - 420);
+
+  return (
+    <div
+      ref={menuRef}
+      className="fixed z-[60] py-1 rounded-lg shadow-xl overflow-y-auto"
+      style={{
+        left,
+        top,
+        maxHeight: '420px',
+        background: 'rgba(17, 24, 39, 0.98)',
+        border: '1px solid rgba(255,255,255,0.1)',
+        minWidth: '200px',
+      }}
+    >
+      {sections.map((section, si) => (
+        <React.Fragment key={section.categoryId}>
+          {si > 0 && <div className="my-1 border-t border-white/10" />}
+          <div
+            className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider"
+            style={{ color: section.color ?? 'rgba(255,255,255,0.35)' }}
+          >
+            {section.label}
+          </div>
+          {section.items.map((item, ii) => (
+            <button
+              key={ii}
+              onClick={() => {
+                item.onClick();
+                onClose();
+              }}
+              className="w-full px-3 py-1.5 text-left text-sm flex items-center gap-2 text-white/90 hover:bg-white/10 transition-colors"
+            >
+              {item.icon && (
+                <span className="w-4 h-4 flex-shrink-0 flex items-center justify-center">
+                  {item.icon}
+                </span>
+              )}
+              <span className="flex-1 truncate">{item.label}</span>
+            </button>
+          ))}
+        </React.Fragment>
+      ))}
+    </div>
+  );
 }
 
 interface ContextMenuProps {
@@ -20,6 +96,9 @@ interface ContextMenuProps {
 
 export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
+  const [activeSubmenuIndex, setActiveSubmenuIndex] = useState<number | null>(null);
+  const [submenuParentRect, setSubmenuParentRect] = useState<DOMRect | null>(null);
+  const clearTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -27,25 +106,33 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
         onClose();
       }
     };
-
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
+      if (e.key === 'Escape') onClose();
     };
-
     document.addEventListener('mousedown', handleClickOutside);
     document.addEventListener('keydown', handleEscape);
-
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleEscape);
     };
   }, [onClose]);
 
-  // Adjust position to keep menu in viewport
   const adjustedX = Math.min(x, window.innerWidth - 200);
-  const adjustedY = Math.min(y, window.innerHeight - items.length * 40);
+  const adjustedY = Math.min(y, window.innerHeight - items.length * 36 - 8);
+
+  const handleMouseEnter = (index: number, e: React.MouseEvent<HTMLButtonElement>) => {
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    if (items[index].submenuSections) {
+      setActiveSubmenuIndex(index);
+      setSubmenuParentRect(e.currentTarget.getBoundingClientRect());
+    } else {
+      // Small delay before hiding submenu so the mouse can move across without flicker
+      clearTimerRef.current = setTimeout(() => {
+        setActiveSubmenuIndex(null);
+        setSubmenuParentRect(null);
+      }, 80);
+    }
+  };
 
   return (
     <div
@@ -61,31 +148,43 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
     >
       {items.map((item, index) => (
         <React.Fragment key={index}>
-          {item.divider && (
-            <div className="my-1 border-t border-white/10" />
-          )}
+          {item.divider && <div className="my-1 border-t border-white/10" />}
           <button
+            onMouseEnter={(e) => handleMouseEnter(index, e)}
             onClick={() => {
-              item.onClick();
+              if (item.submenuSections) return; // submenu items opened on hover, not click
+              item.onClick?.();
               onClose();
             }}
             className={`
-              w-full px-3 py-2 text-left text-sm flex items-center gap-2
-              transition-colors
-              ${item.danger
-                ? 'text-red-400 hover:bg-red-500/20'
-                : 'text-white/90 hover:bg-white/10'
-              }
+              w-full px-3 py-2 text-left text-sm flex items-center gap-2 transition-colors
+              ${item.danger ? 'text-red-400 hover:bg-red-500/20' : 'text-white/90 hover:bg-white/10'}
+              ${activeSubmenuIndex === index ? 'bg-white/10' : ''}
             `}
           >
-            {item.icon && <span className="w-4 h-4">{item.icon}</span>}
+            {item.icon && <span className="w-4 h-4 flex items-center justify-center">{item.icon}</span>}
             <span className="flex-1">{item.label}</span>
+            {item.submenuSections && (
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-white/40 flex-shrink-0">
+                <polyline points="9 18 15 12 9 6" />
+              </svg>
+            )}
             {item.shortcut && (
               <span className="text-xs text-white/40">{item.shortcut}</span>
             )}
           </button>
         </React.Fragment>
       ))}
+
+      {activeSubmenuIndex !== null &&
+        submenuParentRect &&
+        items[activeSubmenuIndex]?.submenuSections && (
+          <SubMenu
+            sections={items[activeSubmenuIndex].submenuSections!}
+            parentRect={submenuParentRect}
+            onClose={onClose}
+          />
+        )}
     </div>
   );
 }

--- a/apps/web/components/editor/Sidebar.tsx
+++ b/apps/web/components/editor/Sidebar.tsx
@@ -27,7 +27,7 @@ interface SidebarProps {
 }
 
 // Category display colors (consistent with create_node.py)
-const CATEGORY_COLORS: Record<PluginCategory, string> = {
+export const CATEGORY_COLORS: Record<PluginCategory, string> = {
   control: '#10B981',
   input: '#22C55E',
   llm: '#10B981',
@@ -39,7 +39,7 @@ const CATEGORY_COLORS: Record<PluginCategory, string> = {
 };
 
 // Category labels
-const CATEGORY_LABELS: Record<PluginCategory, string> = {
+export const CATEGORY_LABELS: Record<PluginCategory, string> = {
   control: 'Control Flow',
   input: 'Input',
   llm: 'LLM',

--- a/apps/web/components/panels/NodeSettings.tsx
+++ b/apps/web/components/panels/NodeSettings.tsx
@@ -9,6 +9,7 @@ import { manifestConfigToNodeFields, evaluateShowWhen, normalizeOptions } from "
 import { useSettingsStore } from "@/stores/settingsStore";
 import { LLM_MODEL_OPTIONS } from "@/lib/constants";
 import type { NodeField } from "@/lib/types";
+import { toast } from "@/stores/toastStore";
 
 // Prompt section for structured prompt building
 export interface PromptSection {
@@ -1859,10 +1860,10 @@ export default function NodeSettings() {
           // Refresh the animations list
           fetchAnimations();
         } else if (response.error) {
-          alert(`Upload failed: ${response.error}`);
+          toast.error(`Upload failed: ${response.error}`);
         }
       } catch (err) {
-        alert("Failed to upload animation file");
+        toast.error("Failed to upload animation file");
       } finally {
         setAnimationUploading(false);
       }
@@ -1886,10 +1887,10 @@ export default function NodeSettings() {
           // Refresh the models list
           fetchModels();
         } else if (response.error) {
-          alert(`Upload failed: ${response.error}`);
+          toast.error(`Upload failed: ${response.error}`);
         }
       } catch (err) {
-        alert("Failed to upload model file");
+        toast.error("Failed to upload model file");
       } finally {
         setModelUploading(false);
       }
@@ -1905,10 +1906,10 @@ export default function NodeSettings() {
         if (response.data) {
           return response.data.url;
         } else if (response.error) {
-          alert(`Upload failed: ${response.error}`);
+          toast.error(`Upload failed: ${response.error}`);
         }
       } catch (err) {
-        alert("Failed to upload image");
+        toast.error("Failed to upload image");
       }
       return null;
     },
@@ -2019,9 +2020,8 @@ export default function NodeSettings() {
   };
 
   const handleDelete = () => {
-    if (confirm("Delete this node?")) {
-      removeNode(selectedNode.id);
-    }
+    removeNode(selectedNode.id);
+    toast.info("ノードを削除しました");
   };
 
   const renderField = (field: NodeField) => {

--- a/plugins/anthropic-llm/node.ts
+++ b/plugins/anthropic-llm/node.ts
@@ -25,6 +25,8 @@ export default class AnthropicLLMNode extends BaseNode {
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.maxTokens = config.maxTokens ?? 1024;
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to Anthropic's valid range [0, 1]
+    this.temperature = Math.max(0, Math.min(1, this.temperature));
 
     if (!this.apiKey) {
       // Auto demo mode when API key is not set
@@ -61,6 +63,7 @@ export default class AnthropicLLMNode extends BaseNode {
       const message = await this.client.messages.create({
         model: this.model,
         max_tokens: this.maxTokens,
+        temperature: this.temperature,
         system: this.systemPrompt,
         messages: [{ role: "user" as const, content: prompt }],
       });

--- a/plugins/delay/node.ts
+++ b/plugins/delay/node.ts
@@ -11,6 +11,7 @@ export default class DelayNode extends BaseNode {
   private randomize = false;
   private randomMin = 500;
   private randomMax = 2000;
+  private abortController: AbortController | null = null;
 
   async setup(config: Record<string, any>, context: NodeContext): Promise<void> {
     this.delayMs = config.delayMs ?? 1000;
@@ -44,13 +45,22 @@ export default class DelayNode extends BaseNode {
     }
 
     await context.log(`Waiting ${delay}ms...`);
-    await new Promise((resolve) => setTimeout(resolve, delay));
+    this.abortController = new AbortController();
+    const { signal } = this.abortController;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, delay);
+      signal.addEventListener("abort", () => {
+        clearTimeout(timer);
+        reject(new Error("Delay cancelled"));
+      });
+    });
     await context.log("Delay complete");
 
     return { output: inputData };
   }
 
   async teardown(): Promise<void> {
-    // No cleanup needed.
+    this.abortController?.abort();
+    this.abortController = null;
   }
 }

--- a/plugins/google-llm/node.ts
+++ b/plugins/google-llm/node.ts
@@ -25,6 +25,8 @@ export default class GoogleLLMNode extends BaseNode {
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.maxTokens = config.maxTokens ?? 1024;
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to Google's valid range [0, 2]
+    this.temperature = Math.max(0, Math.min(2, this.temperature));
 
     if (!this.apiKey) {
       // Auto demo mode when API key is not set

--- a/plugins/groq-llm/node.ts
+++ b/plugins/groq-llm/node.ts
@@ -30,6 +30,8 @@ export default class GroqLLMNode extends BaseNode {
     this.model = config.model ?? "llama-3.3-70b-versatile";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to valid range [0, 2]
+    this.temperature = Math.max(0, Math.min(2, this.temperature));
     this.maxTokens = config.maxTokens ?? 1024;
     this.promptSections = config.promptSections ?? null;
 

--- a/plugins/mistral-llm/node.ts
+++ b/plugins/mistral-llm/node.ts
@@ -29,6 +29,8 @@ export default class MistralLLMNode extends BaseNode {
     this.model = config.model ?? "mistral-small-latest";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to valid range [0, 2]
+    this.temperature = Math.max(0, Math.min(2, this.temperature));
     this.maxTokens = config.maxTokens ?? 1024;
     this.promptSections = config.promptSections ?? null;
 

--- a/plugins/ollama-llm/node.ts
+++ b/plugins/ollama-llm/node.ts
@@ -28,6 +28,8 @@ export default class OllamaLLMNode extends BaseNode {
     this.model = config.model ?? "llama3.2";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to valid range [0, 2]
+    this.temperature = Math.max(0, Math.min(2, this.temperature));
     this.contextLength = config.contextLength ?? 4096;
 
     // Test connection - auto demo mode if unavailable

--- a/plugins/openai-llm/node.ts
+++ b/plugins/openai-llm/node.ts
@@ -47,6 +47,8 @@ export default class OpenAILLMNode extends BaseNode {
     this.model = config.model ?? "gpt-4o-mini";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to valid range [0, 2]
+    this.temperature = Math.max(0, Math.min(2, this.temperature));
     this.maxTokens = config.maxTokens ?? 1024;
     this.reasoningEffort = config.reasoningEffort ?? null;
     this.promptSections = config.promptSections ?? null;

--- a/plugins/text-transform/node.ts
+++ b/plugins/text-transform/node.ts
@@ -54,7 +54,14 @@ export default class TextTransformNode extends BaseNode {
     } else if (this.operation === "trim") {
       result = text.trim();
     } else if (this.operation === "replace") {
-      result = text.split(this.find).join(this.replaceWith);
+      // Guard against empty find string (would split every character)
+      if (this.find.length === 0) {
+        await context.log("replace: 'find' is empty, skipping", "warning");
+      } else if (this.find.length > 1000) {
+        await context.log("replace: 'find' string too long (>1000 chars), skipping", "warning");
+      } else {
+        result = text.split(this.find).join(this.replaceWith);
+      }
     } else if (this.operation === "split_first") {
       const idx = text.indexOf(this.delimiter);
       result = idx >= 0 ? text.substring(0, idx) : text;

--- a/plugins/variable/node.ts
+++ b/plugins/variable/node.ts
@@ -53,7 +53,9 @@ export default class VariableNode extends BaseNode {
         value = String(value);
       }
     } catch (e) {
-      await context.log(`Type conversion failed: ${e}`, "warning");
+      await context.log(`Type conversion failed: ${e}. Falling back to defaultValue.`, "warning");
+      // Use defaultValue as a safe fallback to avoid passing a broken value downstream
+      value = this.defaultValue;
     }
 
     await context.log(`Variable '${this.name}' = ${value}`);


### PR DESCRIPTION
## 概要
ブラウザネイティブの `alert()` / `confirm()` をアプリ内の `toast` 通知に統一。

## 変更箇所
- アニメーションアップロード失敗 → `toast.error()`
- モデルファイルアップロード失敗 → `toast.error()`
- アバター画像アップロード失敗 → `toast.error()`
- ノード削除の `confirm()` → 即削除 + `toast.info("ノードを削除しました")`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node types now organized by category with hover-driven flyout submenus in the add node menu.

* **Bug Fixes**
  * Temperature values clamped to valid ranges across all LLM providers.
  * Delays can now be cancelled during execution.
  * Text replacement operations include input validation guardrails.
  * Enhanced error logging for type conversion failures.
  * Upload failures now display toast notifications instead of blocking alerts.
  * Node deletion is now immediate with informational feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oboroge0/AITuberFlow/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->