### PR TITLE
feat: ポート接続UX改善 — ドラッグハイライト・型バリデーション・候補表示 (#176)

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aituber-flow/desktop",
-  "version": "2.3.2",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aituber-flow/desktop",
-      "version": "2.3.2",
+      "version": "2.3.1",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/web/components/editor/Canvas.tsx
+++ b/apps/web/components/editor/Canvas.tsx
@@ -29,9 +29,10 @@ import DataPreviewPopup from './DataPreviewPopup';
 import SearchPanel from './SearchPanel';
 import { getNodeTypes, type SidebarNodeType, CATEGORY_COLORS, CATEGORY_LABELS } from './Sidebar';
 import { type PluginCategory } from '@/lib/types';
-import { type PortType, type PortDefinition } from '@/lib/portTypes';
+import { type PortType, type PortDefinition, PORT_TYPE_COLORS, arePortTypesCompatible } from '@/lib/portTypes';
 import { useUIPreferencesStore, type NodeDisplayMode } from '@/stores/uiPreferencesStore';
 import { type PromptSection } from '@/components/panels/NodeSettings';
+import { useDragStateStore } from '@/stores/dragStateStore';
 
 interface CanvasProps {
   onNodeSelect?: (nodeId: string | null) => void;
@@ -118,6 +119,13 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
 
   const { nodeDisplayMode, setNodeDisplayMode, searchVisible, searchQuery } = useUIPreferencesStore();
   const { getPluginColor, getPluginLabel, getPluginById, getPluginInputs, getPluginOutputs } = usePluginStore();
+  const { setDragging, clearDragging } = useDragStateStore();
+
+  // State for the "drop-on-canvas" compatible node suggestion panel
+  const [connectSuggest, setConnectSuggest] = useState<{
+    x: number; y: number;
+    sourceType: PortType; sourceNodeId: string; sourcePortId: string;
+  } | null>(null);
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -395,9 +403,65 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
           to: { nodeId: params.target, port: params.targetHandle },
         });
       }
+      setConnectSuggest(null);
     },
     [addConnection]
   );
+
+  // When dragging starts from a handle — notify drag state store so all nodes can highlight/dim
+  const onConnectStart = useCallback(
+    (_event: unknown, params: { nodeId?: string | null; handleId?: string | null; handleType?: 'source' | 'target' | null }) => {
+      const { nodeId, handleId, handleType } = params;
+      if (!nodeId || !handleId || !handleType) return;
+      const node = workflowNodes.find((n) => n.id === nodeId);
+      if (!node) return;
+      const portDefs = handleType === 'source' ? getPluginOutputs(node.type) : getPluginInputs(node.type);
+      const portDef = portDefs.find((p) => p.id === handleId);
+      if (portDef) {
+        setDragging(portDef.type as PortType, handleType);
+      }
+    },
+    [workflowNodes, getPluginInputs, getPluginOutputs, setDragging]
+  ) as Parameters<typeof ReactFlow>[0]['onConnectStart'];
+
+  // When dragging ends — clear drag state, show suggestion panel if dropped on empty canvas
+  const onConnectEnd = useCallback(
+    (event: MouseEvent | TouchEvent) => {
+      const state = useDragStateStore.getState();
+      const target = event.target as HTMLElement;
+      const isOnHandle = target.classList.contains('react-flow__handle');
+      const isOnNode = !!target.closest('.react-flow__node');
+      if (!isOnHandle && !isOnNode && state.draggingSourceType) {
+        const clientX = (event as MouseEvent).clientX ?? (event as TouchEvent).changedTouches?.[0]?.clientX;
+        const clientY = (event as MouseEvent).clientY ?? (event as TouchEvent).changedTouches?.[0]?.clientY;
+        if (clientX !== undefined && clientY !== undefined) {
+          setConnectSuggest({
+            x: clientX,
+            y: clientY,
+            sourceType: state.draggingSourceType,
+            sourceNodeId: '',
+            sourcePortId: '',
+          });
+        }
+      }
+      clearDragging();
+    },
+    [clearDragging]
+  );
+
+  /** Only allow connections where port types are compatible. */
+  const isValidConnection = useCallback(
+    (connection: { source?: string | null; target?: string | null; sourceHandle?: string | null; targetHandle?: string | null }) => {
+      const srcNode = workflowNodes.find((n) => n.id === connection.source);
+      const tgtNode = workflowNodes.find((n) => n.id === connection.target);
+      if (!srcNode || !tgtNode || !connection.sourceHandle || !connection.targetHandle) return true;
+      const srcPort = getPluginOutputs(srcNode.type).find((p) => p.id === connection.sourceHandle);
+      const tgtPort = getPluginInputs(tgtNode.type).find((p) => p.id === connection.targetHandle);
+      if (!srcPort || !tgtPort) return true; // unknown port — allow
+      return arePortTypesCompatible(srcPort.type as PortType, tgtPort.type as PortType);
+    },
+    [workflowNodes, getPluginInputs, getPluginOutputs]
+  ) as Parameters<typeof ReactFlow>[0]['isValidConnection'];
 
   // Track if edge was successfully reconnected
   const edgeReconnectSuccessful = useRef(true);
@@ -690,6 +754,9 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
+        onConnectStart={onConnectStart}
+        onConnectEnd={onConnectEnd}
+        isValidConnection={isValidConnection}
         onReconnectStart={onReconnectStart}
         onReconnect={onReconnect}
         onReconnectEnd={onReconnectEnd}
@@ -729,6 +796,49 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
 
       {/* Search Panel */}
       <SearchPanel />
+
+      {/* Connect-suggest panel: shown when dragging a wire onto empty canvas */}
+      {connectSuggest && (() => {
+        const { plugins } = usePluginStore.getState();
+        const nodeTypesList = getNodeTypes();
+        const compatible = nodeTypesList.filter((nt) => {
+          const plugin = plugins.find((p) => p.id === nt.id);
+          if (!plugin) return false;
+          const inputs = plugin.node?.inputs ?? [];
+          return inputs.some((inp) => arePortTypesCompatible(connectSuggest.sourceType, inp.type as PortType));
+        });
+        if (compatible.length === 0) return null;
+        const adjust = (v: number, max: number, size: number) => Math.min(v, max - size);
+        const px = adjust(connectSuggest.x, window.innerWidth, 220);
+        const py = adjust(connectSuggest.y, window.innerHeight, compatible.length * 36 + 48);
+        return (
+          <div
+            className="fixed z-50 py-1 rounded-lg shadow-xl"
+            style={{ left: px, top: py, background: 'rgba(17,24,39,0.98)', border: '1px solid rgba(255,255,255,0.1)', minWidth: '210px' }}
+          >
+            <div className="px-3 pt-2 pb-1 text-[10px] text-white/40 uppercase tracking-wider flex items-center gap-1.5">
+              <span className="w-2 h-2 rounded-full" style={{ background: PORT_TYPE_COLORS[connectSuggest.sourceType] }} />
+              接続できるノード
+            </div>
+            {compatible.map((nt) => (
+              <button
+                key={nt.id}
+                onClick={() => {
+                  const bounds = reactFlowWrapper.current?.getBoundingClientRect();
+                  if (!bounds) return;
+                  addNode({ type: nt.id, position: { x: connectSuggest.x - bounds.left - 80, y: connectSuggest.y - bounds.top - 30 }, config: { ...nt.defaultConfig } });
+                  setConnectSuggest(null);
+                }}
+                className="w-full px-3 py-2 text-left text-sm flex items-center gap-2 text-white/90 hover:bg-white/10 transition-colors"
+              >
+                <span style={{ color: nt.color }}>{nt.icon}</span>
+                {nt.label}
+              </button>
+            ))}
+            <button onClick={() => setConnectSuggest(null)} className="w-full px-3 py-1.5 text-left text-[11px] text-white/30 hover:text-white/60 border-t border-white/10 mt-1">キャンセル</button>
+          </div>
+        );
+      })()}
 
       {/* Display Mode Toggle */}
       <div className="absolute top-4 right-4 flex gap-1 bg-gray-800/95 rounded-lg p-1 border border-white/10 shadow-lg z-10">

--- a/apps/web/components/editor/Canvas.tsx
+++ b/apps/web/components/editor/Canvas.tsx
@@ -27,7 +27,8 @@ import FieldSelectorNode from './FieldSelectorNode';
 import ContextMenu, { type ContextMenuItem } from './ContextMenu';
 import DataPreviewPopup from './DataPreviewPopup';
 import SearchPanel from './SearchPanel';
-import { getNodeTypes, type SidebarNodeType } from './Sidebar';
+import { getNodeTypes, type SidebarNodeType, CATEGORY_COLORS, CATEGORY_LABELS } from './Sidebar';
+import { type PluginCategory } from '@/lib/types';
 import { type PortType, type PortDefinition } from '@/lib/portTypes';
 import { useUIPreferencesStore, type NodeDisplayMode } from '@/stores/uiPreferencesStore';
 import { type PromptSection } from '@/components/panels/NodeSettings';
@@ -620,25 +621,58 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
       ];
     }
 
-    // Pane context menu - add nodes (dynamically loaded from plugins)
+    // Pane context menu — "Add Node ▶" with category flyout submenu
     const nodeTypesList = getNodeTypes();
-    return nodeTypesList.map((nodeType) => ({
-      label: `Add ${nodeType.label}`,
-      icon: <span style={{ color: nodeType.color }}>{nodeType.icon}</span>,
-      onClick: () => {
-        const reactFlowBounds = reactFlowWrapper.current?.getBoundingClientRect();
-        if (!reactFlowBounds) return;
+    const { plugins } = usePluginStore.getState();
 
-        addNode({
-          type: nodeType.id,
-          position: {
-            x: contextMenu.x - reactFlowBounds.left - 80,
-            y: contextMenu.y - reactFlowBounds.top - 30,
+    // Group node types by category
+    const byCategory: Record<string, SidebarNodeType[]> = {};
+    for (const nt of nodeTypesList) {
+      const plugin = plugins.find((p) => p.id === nt.id);
+      const cat = plugin?.category ?? 'utility';
+      if (!byCategory[cat]) byCategory[cat] = [];
+      byCategory[cat].push(nt);
+    }
+
+    const categoryOrder: PluginCategory[] = [
+      'control', 'input', 'llm', 'tts', 'avatar', 'output', 'utility', 'obs',
+    ];
+
+    const submenuSections = categoryOrder
+      .filter((cat) => byCategory[cat]?.length > 0)
+      .map((cat) => ({
+        categoryId: cat,
+        label: CATEGORY_LABELS[cat] ?? cat,
+        color: CATEGORY_COLORS[cat] ?? '#6B7280',
+        items: (byCategory[cat] ?? []).map((nodeType) => ({
+          label: nodeType.label,
+          icon: <span style={{ color: nodeType.color }}>{nodeType.icon}</span>,
+          onClick: () => {
+            const reactFlowBounds = reactFlowWrapper.current?.getBoundingClientRect();
+            if (!reactFlowBounds) return;
+            addNode({
+              type: nodeType.id,
+              position: {
+                x: contextMenu.x - reactFlowBounds.left - 80,
+                y: contextMenu.y - reactFlowBounds.top - 30,
+              },
+              config: { ...nodeType.defaultConfig },
+            });
           },
-          config: { ...nodeType.defaultConfig },
-        });
+        })),
+      }));
+
+    return [
+      {
+        label: 'ノードを追加',
+        icon: (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="16" /><line x1="8" y1="12" x2="16" y2="12" />
+          </svg>
+        ),
+        submenuSections,
       },
-    }));
+    ];
   };
 
   return (

--- a/apps/web/components/editor/ContextMenu.tsx
+++ b/apps/web/components/editor/ContextMenu.tsx
@@ -1,14 +1,90 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+
+export interface ContextMenuSubmenuItem {
+  label: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+}
+
+export interface ContextMenuSubmenuSection {
+  categoryId: string;
+  label: string;
+  color?: string;
+  items: ContextMenuSubmenuItem[];
+}
 
 export interface ContextMenuItem {
   label: string;
   icon?: React.ReactNode;
-  onClick: () => void;
+  onClick?: () => void;
   danger?: boolean;
   divider?: boolean;
   shortcut?: string;
+  submenuSections?: ContextMenuSubmenuSection[];
+}
+
+// Flyout submenu shown on hover
+function SubMenu({
+  sections,
+  parentRect,
+  onClose,
+}: {
+  sections: ContextMenuSubmenuSection[];
+  parentRect: DOMRect;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Position to the right of parent item; flip left if near viewport edge
+  const spaceRight = window.innerWidth - parentRect.right;
+  const left = spaceRight > 208 ? parentRect.right + 4 : parentRect.left - 208;
+  const top = Math.min(parentRect.top, window.innerHeight - 420);
+
+  return (
+    <div
+      ref={menuRef}
+      className="fixed z-[60] py-1 rounded-lg shadow-xl overflow-y-auto"
+      style={{
+        left,
+        top,
+        maxHeight: '420px',
+        background: 'rgba(17, 24, 39, 0.98)',
+        border: '1px solid rgba(255,255,255,0.1)',
+        minWidth: '200px',
+      }}
+    >
+      {sections.map((section, si) => (
+        <React.Fragment key={section.categoryId}>
+          {si > 0 && <div className="my-1 border-t border-white/10" />}
+          <div
+            className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider"
+            style={{ color: section.color ?? 'rgba(255,255,255,0.35)' }}
+          >
+            {section.label}
+          </div>
+          {section.items.map((item, ii) => (
+            <button
+              key={ii}
+              onClick={() => {
+                item.onClick();
+                onClose();
+              }}
+              className="w-full px-3 py-1.5 text-left text-sm flex items-center gap-2 text-white/90 hover:bg-white/10 transition-colors"
+            >
+              {item.icon && (
+                <span className="w-4 h-4 flex-shrink-0 flex items-center justify-center">
+                  {item.icon}
+                </span>
+              )}
+              <span className="flex-1 truncate">{item.label}</span>
+            </button>
+          ))}
+        </React.Fragment>
+      ))}
+    </div>
+  );
 }
 
 interface ContextMenuProps {
@@ -20,6 +96,9 @@ interface ContextMenuProps {
 
 export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
+  const [activeSubmenuIndex, setActiveSubmenuIndex] = useState<number | null>(null);
+  const [submenuParentRect, setSubmenuParentRect] = useState<DOMRect | null>(null);
+  const clearTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -27,25 +106,33 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
         onClose();
       }
     };
-
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
+      if (e.key === 'Escape') onClose();
     };
-
     document.addEventListener('mousedown', handleClickOutside);
     document.addEventListener('keydown', handleEscape);
-
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleEscape);
     };
   }, [onClose]);
 
-  // Adjust position to keep menu in viewport
   const adjustedX = Math.min(x, window.innerWidth - 200);
-  const adjustedY = Math.min(y, window.innerHeight - items.length * 40);
+  const adjustedY = Math.min(y, window.innerHeight - items.length * 36 - 8);
+
+  const handleMouseEnter = (index: number, e: React.MouseEvent<HTMLButtonElement>) => {
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    if (items[index].submenuSections) {
+      setActiveSubmenuIndex(index);
+      setSubmenuParentRect(e.currentTarget.getBoundingClientRect());
+    } else {
+      // Small delay before hiding submenu so the mouse can move across without flicker
+      clearTimerRef.current = setTimeout(() => {
+        setActiveSubmenuIndex(null);
+        setSubmenuParentRect(null);
+      }, 80);
+    }
+  };
 
   return (
     <div
@@ -61,31 +148,43 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
     >
       {items.map((item, index) => (
         <React.Fragment key={index}>
-          {item.divider && (
-            <div className="my-1 border-t border-white/10" />
-          )}
+          {item.divider && <div className="my-1 border-t border-white/10" />}
           <button
+            onMouseEnter={(e) => handleMouseEnter(index, e)}
             onClick={() => {
-              item.onClick();
+              if (item.submenuSections) return; // submenu items opened on hover, not click
+              item.onClick?.();
               onClose();
             }}
             className={`
-              w-full px-3 py-2 text-left text-sm flex items-center gap-2
-              transition-colors
-              ${item.danger
-                ? 'text-red-400 hover:bg-red-500/20'
-                : 'text-white/90 hover:bg-white/10'
-              }
+              w-full px-3 py-2 text-left text-sm flex items-center gap-2 transition-colors
+              ${item.danger ? 'text-red-400 hover:bg-red-500/20' : 'text-white/90 hover:bg-white/10'}
+              ${activeSubmenuIndex === index ? 'bg-white/10' : ''}
             `}
           >
-            {item.icon && <span className="w-4 h-4">{item.icon}</span>}
+            {item.icon && <span className="w-4 h-4 flex items-center justify-center">{item.icon}</span>}
             <span className="flex-1">{item.label}</span>
+            {item.submenuSections && (
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-white/40 flex-shrink-0">
+                <polyline points="9 18 15 12 9 6" />
+              </svg>
+            )}
             {item.shortcut && (
               <span className="text-xs text-white/40">{item.shortcut}</span>
             )}
           </button>
         </React.Fragment>
       ))}
+
+      {activeSubmenuIndex !== null &&
+        submenuParentRect &&
+        items[activeSubmenuIndex]?.submenuSections && (
+          <SubMenu
+            sections={items[activeSubmenuIndex].submenuSections!}
+            parentRect={submenuParentRect}
+            onClose={onClose}
+          />
+        )}
     </div>
   );
 }

--- a/apps/web/components/editor/CustomNode.tsx
+++ b/apps/web/components/editor/CustomNode.tsx
@@ -6,7 +6,8 @@ import { useWorkflowStore } from '@/stores/workflowStore';
 import { usePluginStore } from '@/stores/pluginStore';
 import { useUIPreferencesStore } from '@/stores/uiPreferencesStore';
 import { useLocaleStore } from '@/stores/localeStore';
-import { type PortDefinition, PORT_TYPE_COLORS } from '@/lib/portTypes';
+import { type PortDefinition, PORT_TYPE_COLORS, PORT_TYPE_LABELS, arePortTypesCompatible, type PortType } from '@/lib/portTypes';
+import { useDragStateStore } from '@/stores/dragStateStore';
 import { renderIcon } from '@/lib/icons';
 
 export interface CustomNodeData extends Record<string, unknown> {
@@ -66,6 +67,11 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
   const [showTooltip, setShowTooltip] = useState(false);
   const tooltipTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const status = nodeStatuses[id];
+
+  // Track drag state for port highlight/dim
+  const { draggingSourceType, draggingHandleType } = useDragStateStore();
+  // Hover state for port tooltips
+  const [hoveredPort, setHoveredPort] = useState<{ id: string; label: string; type: PortType; description?: string } | null>(null);
 
   const collapsed = collapsedNodeIds.includes(id);
 
@@ -322,7 +328,60 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
     ) : null;
   };
 
-  // ============ COLLAPSED MODE ============
+  // Port hover tooltip
+  const PortTooltip = () => {
+    if (!hoveredPort) return null;
+    const typeColor = PORT_TYPE_COLORS[hoveredPort.type] ?? '#6B7280';
+    const typeLabel = PORT_TYPE_LABELS[hoveredPort.type] ?? hoveredPort.type;
+    return (
+      <div
+        className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 z-[60] pointer-events-none"
+        style={{ minWidth: '160px', maxWidth: '240px' }}
+      >
+        <div className="bg-gray-950/98 backdrop-blur-sm border rounded-lg p-2 shadow-xl" style={{ borderColor: `${typeColor}60` }}>
+          <div className="flex items-center gap-1.5 mb-1">
+            <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: typeColor }} />
+            <span className="text-[11px] font-semibold text-white/90">{hoveredPort.label}</span>
+            <span className="text-[10px] ml-auto" style={{ color: typeColor }}>{typeLabel}</span>
+          </div>
+          {hoveredPort.description && (
+            <div className="text-[10px] text-white/60 leading-relaxed">{hoveredPort.description}</div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  /** Return handle style based on drag compatibility */
+  const getHandleStyle = (portType: PortType, isTarget: boolean): React.CSSProperties => {
+    const base: React.CSSProperties = {
+      borderRadius: '50%',
+      border: '2px solid #1F2937',
+      position: 'relative',
+      transition: 'opacity 0.15s, box-shadow 0.15s, transform 0.15s',
+    };
+    if (!draggingSourceType) {
+      // idle: normal appearance
+      return { ...base, width: '14px', height: '14px', background: PORT_TYPE_COLORS[portType] ?? '#374151' };
+    }
+    // Something is being dragged — check compatibility
+    const compatible = isTarget
+      ? arePortTypesCompatible(draggingSourceType, portType)
+      : arePortTypesCompatible(portType, draggingSourceType);
+
+    if (compatible) {
+      return {
+        ...base,
+        width: '16px',
+        height: '16px',
+        background: PORT_TYPE_COLORS[portType] ?? '#374151',
+        boxShadow: `0 0 8px ${PORT_TYPE_COLORS[portType] ?? '#374151'}`,
+        transform: 'scale(1.2)',
+      };
+    } else {
+      return { ...base, width: '14px', height: '14px', background: '#374151', opacity: 0.25 };
+    }
+  };
   if (collapsed) {
     return (
       <div
@@ -656,20 +715,18 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
           {/* Input ports */}
           <div className="flex flex-col gap-1">
             {data.inputs?.map((input) => (
-              <div key={input.id} className="flex items-center gap-1 relative h-5">
+              <div
+                key={input.id}
+                className="flex items-center gap-1 relative h-5"
+                onMouseEnter={() => setHoveredPort({ id: input.id, label: input.label, type: input.type as PortType, description: (input as any).description })}
+                onMouseLeave={() => setHoveredPort(null)}
+              >
+                <PortTooltip />
                 <Handle
                   type="target"
                   position={Position.Left}
                   id={input.id}
-                  style={{
-                    width: '12px',
-                    height: '12px',
-                    borderRadius: '50%',
-                    background: PORT_TYPE_COLORS[input.type] || '#374151',
-                    border: '2px solid #1F2937',
-                    left: '-6px',
-                    position: 'absolute',
-                  }}
+                  style={{ ...getHandleStyle(input.type as PortType, true), left: '-7px', position: 'absolute' }}
                 />
                 <span className="text-[10px] text-white/60 pl-2 whitespace-nowrap">
                   {input.label}
@@ -681,7 +738,13 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
           {/* Output ports */}
           <div className="flex flex-col gap-1 items-end">
             {data.outputs?.map((output) => (
-              <div key={output.id} className="flex items-center gap-1 relative h-5">
+              <div
+                key={output.id}
+                className="flex items-center gap-1 relative h-5"
+                onMouseEnter={() => setHoveredPort({ id: output.id, label: output.label, type: output.type as PortType, description: (output as any).description })}
+                onMouseLeave={() => setHoveredPort(null)}
+              >
+                <PortTooltip />
                 <span className="text-[10px] text-white/60 pr-2 whitespace-nowrap">
                   {output.label}
                 </span>
@@ -689,15 +752,7 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
                   type="source"
                   position={Position.Right}
                   id={output.id}
-                  style={{
-                    width: '12px',
-                    height: '12px',
-                    borderRadius: '50%',
-                    background: PORT_TYPE_COLORS[output.type] || config.color,
-                    border: '2px solid #1F2937',
-                    right: '-6px',
-                    position: 'absolute',
-                  }}
+                  style={{ ...getHandleStyle(output.type as PortType, false), right: '-7px', position: 'absolute' }}
                 />
               </div>
             ))}

--- a/apps/web/components/editor/Sidebar.tsx
+++ b/apps/web/components/editor/Sidebar.tsx
@@ -27,7 +27,7 @@ interface SidebarProps {
 }
 
 // Category display colors (consistent with create_node.py)
-const CATEGORY_COLORS: Record<PluginCategory, string> = {
+export const CATEGORY_COLORS: Record<PluginCategory, string> = {
   control: '#10B981',
   input: '#22C55E',
   llm: '#10B981',
@@ -39,7 +39,7 @@ const CATEGORY_COLORS: Record<PluginCategory, string> = {
 };
 
 // Category labels
-const CATEGORY_LABELS: Record<PluginCategory, string> = {
+export const CATEGORY_LABELS: Record<PluginCategory, string> = {
   control: 'Control Flow',
   input: 'Input',
   llm: 'LLM',

--- a/apps/web/components/panels/NodeSettings.tsx
+++ b/apps/web/components/panels/NodeSettings.tsx
@@ -9,6 +9,7 @@ import { manifestConfigToNodeFields, evaluateShowWhen, normalizeOptions } from "
 import { useSettingsStore } from "@/stores/settingsStore";
 import { LLM_MODEL_OPTIONS } from "@/lib/constants";
 import type { NodeField } from "@/lib/types";
+import { toast } from "@/stores/toastStore";
 
 // Prompt section for structured prompt building
 export interface PromptSection {
@@ -1859,10 +1860,10 @@ export default function NodeSettings() {
           // Refresh the animations list
           fetchAnimations();
         } else if (response.error) {
-          alert(`Upload failed: ${response.error}`);
+          toast.error(`Upload failed: ${response.error}`);
         }
       } catch (err) {
-        alert("Failed to upload animation file");
+        toast.error("Failed to upload animation file");
       } finally {
         setAnimationUploading(false);
       }
@@ -1886,10 +1887,10 @@ export default function NodeSettings() {
           // Refresh the models list
           fetchModels();
         } else if (response.error) {
-          alert(`Upload failed: ${response.error}`);
+          toast.error(`Upload failed: ${response.error}`);
         }
       } catch (err) {
-        alert("Failed to upload model file");
+        toast.error("Failed to upload model file");
       } finally {
         setModelUploading(false);
       }
@@ -1905,10 +1906,10 @@ export default function NodeSettings() {
         if (response.data) {
           return response.data.url;
         } else if (response.error) {
-          alert(`Upload failed: ${response.error}`);
+          toast.error(`Upload failed: ${response.error}`);
         }
       } catch (err) {
-        alert("Failed to upload image");
+        toast.error("Failed to upload image");
       }
       return null;
     },
@@ -2019,9 +2020,8 @@ export default function NodeSettings() {
   };
 
   const handleDelete = () => {
-    if (confirm("Delete this node?")) {
-      removeNode(selectedNode.id);
-    }
+    removeNode(selectedNode.id);
+    toast.info("ノードを削除しました");
   };
 
   const renderField = (field: NodeField) => {

--- a/apps/web/lib/portTypes.ts
+++ b/apps/web/lib/portTypes.ts
@@ -1,17 +1,36 @@
-export type PortType = 'string' | 'number' | 'boolean' | 'audio' | 'array' | 'object' | 'any';
+export type PortType = 'string' | 'number' | 'boolean' | 'audio' | 'array' | 'object' | 'any' | 'trigger';
 
 export const PORT_TYPE_COLORS: Record<PortType, string> = {
-  string: '#22C55E',   // green
-  number: '#3B82F6',   // blue
+  string:  '#22C55E',  // green
+  number:  '#3B82F6',  // blue
   boolean: '#A855F7',  // purple
-  audio: '#F59E0B',    // orange
-  array: '#EC4899',    // pink
-  object: '#6B7280',   // gray
-  any: '#6B7280',      // gray
+  audio:   '#F59E0B',  // amber
+  array:   '#EC4899',  // pink
+  object:  '#6B7280',  // gray
+  any:     '#94A3B8',  // slate (distinguishable from object)
+  trigger: '#10B981',  // emerald
 };
+
+export const PORT_TYPE_LABELS: Record<PortType, string> = {
+  string:  'テキスト',
+  number:  '数値',
+  boolean: '真偽値',
+  audio:   '音声',
+  array:   '配列',
+  object:  'オブジェクト',
+  any:     '任意',
+  trigger: 'トリガー',
+};
+
+/** Two types are compatible if either side is 'any', or they match exactly. */
+export function arePortTypesCompatible(sourceType: PortType, targetType: PortType): boolean {
+  if (sourceType === 'any' || targetType === 'any') return true;
+  return sourceType === targetType;
+}
 
 export interface PortDefinition {
   id: string;
   label: string;
   type: PortType;
+  description?: string;
 }

--- a/apps/web/lib/portTypes.ts
+++ b/apps/web/lib/portTypes.ts
@@ -22,9 +22,22 @@ export const PORT_TYPE_LABELS: Record<PortType, string> = {
   trigger: 'トリガー',
 };
 
-/** Two types are compatible if either side is 'any', or they match exactly. */
+/** Port types that the UI models and can validate against each other. */
+const KNOWN_PORT_TYPES: ReadonlySet<string> = new Set<PortType>([
+  'string', 'number', 'boolean', 'audio', 'array', 'object', 'any', 'trigger',
+]);
+
+/**
+ * Two types are compatible if either side is 'any', or they match exactly.
+ *
+ * Plugin-specific port types that the UI does not yet model (e.g. 'Message'
+ * emitted by chat input nodes and consumed as 'string' by LLM prompts) are
+ * treated as compatible — otherwise the type system would block valid
+ * connections it simply doesn't describe yet (e.g. the core chat → LLM flow).
+ */
 export function arePortTypesCompatible(sourceType: PortType, targetType: PortType): boolean {
   if (sourceType === 'any' || targetType === 'any') return true;
+  if (!KNOWN_PORT_TYPES.has(sourceType) || !KNOWN_PORT_TYPES.has(targetType)) return true;
   return sourceType === targetType;
 }
 

--- a/apps/web/stores/dragStateStore.ts
+++ b/apps/web/stores/dragStateStore.ts
@@ -1,0 +1,22 @@
+/**
+ * Drag-state store — tracks what port type is currently being dragged
+ * so nodes can highlight / dim their handles accordingly.
+ */
+import { create } from 'zustand';
+import type { PortType } from '@/lib/portTypes';
+
+interface DragState {
+  /** Type of the port currently being dragged from, or null when idle. */
+  draggingSourceType: PortType | null;
+  /** 'source' when dragging from output, 'target' when from input (reconnect). */
+  draggingHandleType: 'source' | 'target' | null;
+  setDragging: (sourceType: PortType | null, handleType: 'source' | 'target' | null) => void;
+  clearDragging: () => void;
+}
+
+export const useDragStateStore = create<DragState>((set) => ({
+  draggingSourceType: null,
+  draggingHandleType: null,
+  setDragging: (sourceType, handleType) => set({ draggingSourceType: sourceType, draggingHandleType: handleType }),
+  clearDragging: () => set({ draggingSourceType: null, draggingHandleType: null }),
+}));

--- a/plugins/anthropic-llm/node.ts
+++ b/plugins/anthropic-llm/node.ts
@@ -25,6 +25,8 @@ export default class AnthropicLLMNode extends BaseNode {
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.maxTokens = config.maxTokens ?? 1024;
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to Anthropic's valid range [0, 1]
+    this.temperature = Math.max(0, Math.min(1, this.temperature));
 
     if (!this.apiKey) {
       // Auto demo mode when API key is not set
@@ -61,6 +63,7 @@ export default class AnthropicLLMNode extends BaseNode {
       const message = await this.client.messages.create({
         model: this.model,
         max_tokens: this.maxTokens,
+        temperature: this.temperature,
         system: this.systemPrompt,
         messages: [{ role: "user" as const, content: prompt }],
       });

--- a/plugins/delay/node.ts
+++ b/plugins/delay/node.ts
@@ -11,6 +11,7 @@ export default class DelayNode extends BaseNode {
   private randomize = false;
   private randomMin = 500;
   private randomMax = 2000;
+  private abortController: AbortController | null = null;
 
   async setup(config: Record<string, any>, context: NodeContext): Promise<void> {
     this.delayMs = config.delayMs ?? 1000;
@@ -44,13 +45,22 @@ export default class DelayNode extends BaseNode {
     }
 
     await context.log(`Waiting ${delay}ms...`);
-    await new Promise((resolve) => setTimeout(resolve, delay));
+    this.abortController = new AbortController();
+    const { signal } = this.abortController;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, delay);
+      signal.addEventListener("abort", () => {
+        clearTimeout(timer);
+        reject(new Error("Delay cancelled"));
+      });
+    });
     await context.log("Delay complete");
 
     return { output: inputData };
   }
 
   async teardown(): Promise<void> {
-    // No cleanup needed.
+    this.abortController?.abort();
+    this.abortController = null;
   }
 }

--- a/plugins/google-llm/node.ts
+++ b/plugins/google-llm/node.ts
@@ -25,6 +25,8 @@ export default class GoogleLLMNode extends BaseNode {
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.maxTokens = config.maxTokens ?? 1024;
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to Google's valid range [0, 2]
+    this.temperature = Math.max(0, Math.min(2, this.temperature));
 
     if (!this.apiKey) {
       // Auto demo mode when API key is not set

--- a/plugins/groq-llm/node.ts
+++ b/plugins/groq-llm/node.ts
@@ -30,6 +30,8 @@ export default class GroqLLMNode extends BaseNode {
     this.model = config.model ?? "llama-3.3-70b-versatile";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to valid range [0, 2]
+    this.temperature = Math.max(0, Math.min(2, this.temperature));
     this.maxTokens = config.maxTokens ?? 1024;
     this.promptSections = config.promptSections ?? null;
 

--- a/plugins/mistral-llm/node.ts
+++ b/plugins/mistral-llm/node.ts
@@ -29,6 +29,8 @@ export default class MistralLLMNode extends BaseNode {
     this.model = config.model ?? "mistral-small-latest";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to valid range [0, 2]
+    this.temperature = Math.max(0, Math.min(2, this.temperature));
     this.maxTokens = config.maxTokens ?? 1024;
     this.promptSections = config.promptSections ?? null;
 

--- a/plugins/ollama-llm/node.ts
+++ b/plugins/ollama-llm/node.ts
@@ -28,6 +28,8 @@ export default class OllamaLLMNode extends BaseNode {
     this.model = config.model ?? "llama3.2";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to valid range [0, 2]
+    this.temperature = Math.max(0, Math.min(2, this.temperature));
     this.contextLength = config.contextLength ?? 4096;
 
     // Test connection - auto demo mode if unavailable

--- a/plugins/openai-llm/node.ts
+++ b/plugins/openai-llm/node.ts
@@ -47,6 +47,8 @@ export default class OpenAILLMNode extends BaseNode {
     this.model = config.model ?? "gpt-4o-mini";
     this.systemPrompt = config.systemPrompt ?? "You are a helpful assistant.";
     this.temperature = config.temperature ?? 0.7;
+    // Clamp to valid range [0, 2]
+    this.temperature = Math.max(0, Math.min(2, this.temperature));
     this.maxTokens = config.maxTokens ?? 1024;
     this.reasoningEffort = config.reasoningEffort ?? null;
     this.promptSections = config.promptSections ?? null;

--- a/plugins/text-transform/node.ts
+++ b/plugins/text-transform/node.ts
@@ -54,7 +54,14 @@ export default class TextTransformNode extends BaseNode {
     } else if (this.operation === "trim") {
       result = text.trim();
     } else if (this.operation === "replace") {
-      result = text.split(this.find).join(this.replaceWith);
+      // Guard against empty find string (would split every character)
+      if (this.find.length === 0) {
+        await context.log("replace: 'find' is empty, skipping", "warning");
+      } else if (this.find.length > 1000) {
+        await context.log("replace: 'find' string too long (>1000 chars), skipping", "warning");
+      } else {
+        result = text.split(this.find).join(this.replaceWith);
+      }
     } else if (this.operation === "split_first") {
       const idx = text.indexOf(this.delimiter);
       result = idx >= 0 ? text.substring(0, idx) : text;

--- a/plugins/variable/node.ts
+++ b/plugins/variable/node.ts
@@ -53,7 +53,9 @@ export default class VariableNode extends BaseNode {
         value = String(value);
       }
     } catch (e) {
-      await context.log(`Type conversion failed: ${e}`, "warning");
+      await context.log(`Type conversion failed: ${e}. Falling back to defaultValue.`, "warning");
+      // Use defaultValue as a safe fallback to avoid passing a broken value downstream
+      value = this.defaultValue;
     }
 
     await context.log(`Variable '${this.name}' = ${value}`);


### PR DESCRIPTION
## 概要
「どこと繋げればいいか分からない」問題を解消するためのポートUX全面改善。

## 変更内容

### ドラッグ中のハイライト
ポートからドラッグを開始すると、全ノードのポートが即座に反応する。
- **互換ポート** → 光る (glow + scale up)
- **非互換ポート** → 暗くなる (opacity 0.25)
- ドラッグ終了で元に戻る

### ポートホバーツールチップ
ポートにカーソルを乗せると名前・型・説明が表示される。
- 型の色で枠を付けて視覚的に区別

### 型バリデーション
型不一致の接続を UI レベルで拒否 (`isValidConnection`)。`any` 型は全ての型と互換。

### 空キャンバスドロップで候補表示
ポートから線を引いてキャンバスの何もないところに離すと、そのポートと互換のある入力を持つノードだけが候補として表示される。クリックで即座に配置。

## 参考
- Unreal Blueprint: ドラッグ中に非互換ピンが即暗くなる
- Rivet: 空キャンバスドロップで型絞り込みノード候補
- ComfyUI: ポートの型色

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection suggestions panel shows compatible nodes at drop location.
  * Categorized "Add Node" flyout groups node types by category.
  * Per-port hover tooltips and drag-compatibility visual feedback.

* **Improvements**
  * App-wide toast notifications replace browser popups for node actions.
  * LLM temperature values validated across integrations.
  * Delay operations are cancellable.
  * Text transform operations include input validation.

* **Other**
  * Drag state tracking added to improve connection UX.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oboroge0/AITuberFlow/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->