### PR TITLE
feat: ワークフロー接続の整合性チェックを追加

### DIFF
--- a/apps/server-ts/src/engine/connection-integrity.ts
+++ b/apps/server-ts/src/engine/connection-integrity.ts
@@ -1,0 +1,227 @@
+/**
+ * Connection integrity checks for workflow validation.
+ *
+ * The engine resolves node inputs in executor.ts `getNodeInputs` with a very
+ * tolerant rule: if a connection's source port is not found on the upstream
+ * node's output object, it silently passes the *entire* upstream output object
+ * downstream, and a target port that does not exist is simply written as a key.
+ * As a result none of the following are caught at run time:
+ *   - connecting an OUTPUT port to another OUTPUT port (reversed direction)
+ *   - connecting to/from a port id that does not exist on the node
+ *   - mismatched port types
+ *
+ * The visual editor's `isValidConnection` only blocks *type*-incompatible drags
+ * and even then allows unknown ports, and does nothing for workflows created via
+ * the API / import / DB. This module adds manifest-based connection checks so
+ * malformed graphs are surfaced before they fail silently.
+ *
+ * Severity (decided with the maintainer):
+ *   - reversed direction / non-existent port on a node that HAS ports → error
+ *   - any connection touching a node that declares NO ports (e.g.
+ *     avatar-configuration, which is event-driven) → warning (it is a no-op)
+ *   - type mismatch → warning
+ *
+ * False-positive avoidance:
+ *   - endpoints whose node has no manifest are skipped
+ *   - the `to` side of a node with dynamic input ports (config containing a
+ *     prompt-builder / input-list field, e.g. openai-llm / text-transform) is
+ *     skipped, because those inputs are generated from config at edit time and
+ *     are not present in the static manifest. Must stay in sync with the dynamic
+ *     port generation in apps/web/components/editor/Canvas.tsx.
+ */
+
+import type { ValidationIssue } from "./validator";
+
+interface NodeLike {
+  id: string;
+  type: string;
+  config?: Record<string, unknown>;
+}
+
+interface ConnectionLike {
+  id: string;
+  from: { nodeId: string; port: string };
+  to: { nodeId: string; port: string };
+}
+
+interface ManifestPort {
+  id: string;
+  type: string;
+}
+
+interface ManifestLike {
+  id: string;
+  name: string;
+  category?: string;
+  node?: {
+    inputs?: ManifestPort[];
+    outputs?: ManifestPort[];
+  };
+  config?: Record<string, { type: string }>;
+}
+
+/** Port types the validator models; anything else is treated as compatible. */
+const KNOWN_PORT_TYPES = new Set([
+  "string",
+  "number",
+  "boolean",
+  "audio",
+  "array",
+  "object",
+  "any",
+  "trigger",
+]);
+
+/**
+ * Mirror of the frontend arePortTypesCompatible (apps/web/lib/portTypes.ts):
+ * compatible if either side is 'any', either side is a type the validator does
+ * not model, or the two types are exactly equal.
+ */
+function arePortTypesCompatible(sourceType: string, targetType: string): boolean {
+  if (sourceType === "any" || targetType === "any") return true;
+  if (!KNOWN_PORT_TYPES.has(sourceType) || !KNOWN_PORT_TYPES.has(targetType)) {
+    return true;
+  }
+  return sourceType === targetType;
+}
+
+/**
+ * Config field types whose presence makes a node's INPUT ports dynamic
+ * (generated from config at edit time, not declared in the manifest).
+ * Keep in sync with Canvas.tsx dynamic port generation.
+ */
+const DYNAMIC_INPUT_CONFIG_TYPES = new Set(["prompt-builder", "input-list"]);
+
+function hasDynamicInputs(manifest: ManifestLike | null | undefined): boolean {
+  if (!manifest?.config) return false;
+  return Object.values(manifest.config).some((field) =>
+    DYNAMIC_INPUT_CONFIG_TYPES.has(field?.type),
+  );
+}
+
+function inputsOf(manifest: ManifestLike | null | undefined): ManifestPort[] {
+  return manifest?.node?.inputs ?? [];
+}
+
+function outputsOf(manifest: ManifestLike | null | undefined): ManifestPort[] {
+  return manifest?.node?.outputs ?? [];
+}
+
+function hasNoPorts(manifest: ManifestLike | null | undefined): boolean {
+  return inputsOf(manifest).length === 0 && outputsOf(manifest).length === 0;
+}
+
+/**
+ * Validate every connection against the source/target node manifests.
+ *
+ * @param nodes        workflow nodes
+ * @param connections  workflow connections
+ * @param manifests    node type → manifest (or null when not found)
+ * @param resolvePortId optional legacy port-id alias resolver (e.g. snake→camel
+ *   after the config-naming refactor). Defaults to identity so this works on a
+ *   tree that has no alias table.
+ */
+export function checkInvalidConnections(
+  nodes: NodeLike[],
+  connections: ConnectionLike[],
+  manifests: Map<string, ManifestLike | null>,
+  resolvePortId: (port: string) => string = (p) => p,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
+  // Emit the "node has no ports" warning at most once per node, not per edge.
+  const warnedNoPortNodes = new Set<string>();
+
+  const nameOf = (node: NodeLike): string =>
+    manifests.get(node.type)?.name || node.type;
+
+  const warnNoPorts = (node: NodeLike): void => {
+    if (warnedNoPortNodes.has(node.id)) return;
+    warnedNoPortNodes.add(node.id);
+    issues.push({
+      nodeId: node.id,
+      nodeName: nameOf(node),
+      level: "warning",
+      message: `「${nameOf(node)}」は入出力ポートを持たないため、この接続は無視されます`,
+    });
+  };
+
+  for (const conn of connections) {
+    const fromNode = nodeById.get(conn.from.nodeId);
+    const toNode = nodeById.get(conn.to.nodeId);
+
+    // Dangling connection: references a node that is not in the workflow.
+    if (!fromNode || !toNode) {
+      const missingId = !fromNode ? conn.from.nodeId : conn.to.nodeId;
+      issues.push({
+        nodeId: missingId,
+        nodeName: missingId,
+        level: "error",
+        message: `接続が存在しないノード「${missingId}」を参照しています`,
+      });
+      continue;
+    }
+
+    const fromManifest = manifests.get(fromNode.type);
+    const toManifest = manifests.get(toNode.type);
+    const fromPort = resolvePortId(conn.from.port);
+    const toPort = resolvePortId(conn.to.port);
+
+    // ── Source endpoint must reference an OUTPUT port of fromNode ──
+    if (fromManifest) {
+      if (hasNoPorts(fromManifest)) {
+        warnNoPorts(fromNode);
+      } else if (!outputsOf(fromManifest).some((p) => p.id === fromPort)) {
+        const isInput = inputsOf(fromManifest).some((p) => p.id === fromPort);
+        issues.push({
+          nodeId: fromNode.id,
+          nodeName: nameOf(fromNode),
+          level: "error",
+          message: isInput
+            ? `接続元が入力ポート「${conn.from.port}」になっています（出力ポートから接続してください）`
+            : `接続元の出力ポート「${conn.from.port}」が存在しません`,
+        });
+      }
+    }
+
+    // ── Target endpoint must reference an INPUT port of toNode ──
+    // Skip nodes with dynamic inputs (their inputs aren't in the manifest).
+    if (toManifest && !hasDynamicInputs(toManifest)) {
+      if (hasNoPorts(toManifest)) {
+        warnNoPorts(toNode);
+      } else if (!inputsOf(toManifest).some((p) => p.id === toPort)) {
+        const isOutput = outputsOf(toManifest).some((p) => p.id === toPort);
+        issues.push({
+          nodeId: toNode.id,
+          nodeName: nameOf(toNode),
+          level: "error",
+          message: isOutput
+            ? `接続先が出力ポート「${conn.to.port}」になっています（入力ポートへ接続してください）`
+            : `接続先の入力ポート「${conn.to.port}」が存在しません`,
+        });
+      }
+    }
+
+    // ── Type compatibility (warning) — only when both ends resolve cleanly ──
+    if (
+      fromManifest &&
+      toManifest &&
+      !hasDynamicInputs(toManifest) &&
+      !hasNoPorts(fromManifest) &&
+      !hasNoPorts(toManifest)
+    ) {
+      const outPort = outputsOf(fromManifest).find((p) => p.id === fromPort);
+      const inPort = inputsOf(toManifest).find((p) => p.id === toPort);
+      if (outPort && inPort && !arePortTypesCompatible(outPort.type, inPort.type)) {
+        issues.push({
+          nodeId: toNode.id,
+          nodeName: nameOf(toNode),
+          level: "warning",
+          message: `ポートの型が一致しません: 「${conn.from.port}」(${outPort.type}) → 「${conn.to.port}」(${inPort.type})`,
+        });
+      }
+    }
+  }
+
+  return issues;
+}

--- a/apps/server-ts/src/engine/validator.ts
+++ b/apps/server-ts/src/engine/validator.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { db } from "../db/database";
 import { globalSettings } from "../db/schema";
 import { SOURCE_NODE_TYPES, getPluginsDir } from "./plugin-loader";
+import { checkInvalidConnections } from "./connection-integrity";
 
 // ─── Types ───────────────────────────────────────────────────────
 
@@ -480,6 +481,9 @@ export async function validateWorkflow(workflowData: WorkflowData): Promise<Vali
   // 5. API key check
   issues.push(...checkApiKeys(nodes, settings));
 
+  // 6. Invalid connections (port direction / existence / type compatibility)
+  issues.push(...checkInvalidConnections(nodes, connections, manifests));
+
   return issues;
 }
 
@@ -514,6 +518,9 @@ export function validateWorkflowSync(
 
   // 5. API key check
   issues.push(...checkApiKeys(nodes, settings));
+
+  // 6. Invalid connections (port direction / existence / type compatibility)
+  issues.push(...checkInvalidConnections(nodes, connections, manifests));
 
   return issues;
 }

--- a/tests/engine/connection-integrity.test.ts
+++ b/tests/engine/connection-integrity.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Connection Integrity - Unit Tests
+ *
+ * Tests checkInvalidConnections: detection of reversed port direction,
+ * non-existent ports, type mismatches, no-port (event-driven) nodes, dynamic
+ * input nodes, and dangling connections. Also covers the wiring through
+ * validateWorkflowSync.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { checkInvalidConnections } from "../../apps/server-ts/src/engine/connection-integrity";
+import { validateWorkflowSync } from "../../apps/server-ts/src/engine/validator";
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+function node(id: string, type: string, config: Record<string, unknown> = {}) {
+  return { id, type, config };
+}
+
+function conn(
+  id: string,
+  fromNodeId: string,
+  fromPort: string,
+  toNodeId: string,
+  toPort: string,
+) {
+  return {
+    id,
+    from: { nodeId: fromNodeId, port: fromPort },
+    to: { nodeId: toNodeId, port: toPort },
+  };
+}
+
+interface Port {
+  id: string;
+  type: string;
+}
+
+function manifest(
+  id: string,
+  name: string,
+  inputs: Port[] = [],
+  outputs: Port[] = [],
+  config: Record<string, { type: string }> = {},
+) {
+  return { id, name, config, node: { inputs, outputs } };
+}
+
+// Common manifests
+const emotion = manifest(
+  "emotion-analyzer",
+  "Emotion Analyzer",
+  [{ id: "text", type: "string" }],
+  [
+    { id: "expression", type: "string" },
+    { id: "intensity", type: "number" },
+    { id: "text", type: "string" },
+  ],
+);
+const motion = manifest(
+  "motion-trigger",
+  "Motion Trigger",
+  [{ id: "trigger", type: "any" }],
+  [
+    { id: "expression", type: "string" },
+    { id: "intensity", type: "number" },
+    { id: "motionUrl", type: "string" },
+  ],
+);
+const avatar = manifest("avatar-configuration", "Avatar Configuration", [], []);
+const ttsAudio = manifest(
+  "voicevox-tts",
+  "VOICEVOX TTS",
+  [{ id: "text", type: "string" }],
+  [{ id: "audio", type: "audio" }],
+);
+const lipSync = manifest(
+  "lip-sync",
+  "Lip Sync",
+  [
+    { id: "audio", type: "audio" },
+    { id: "audioUrl", type: "string" },
+  ],
+  [
+    { id: "mouth_values", type: "array" },
+    { id: "duration", type: "number" },
+    { id: "audio", type: "audio" },
+  ],
+);
+// openai-llm: dynamic inputs via prompt-builder config field
+const openaiLlm = manifest(
+  "openai-llm",
+  "OpenAI LLM",
+  [{ id: "prompt", type: "string" }],
+  [{ id: "response", type: "string" }],
+  { promptSections: { type: "prompt-builder" } },
+);
+
+function manifestMap(...ms: ReturnType<typeof manifest>[]) {
+  return new Map(ms.map((m) => [m.id, m]));
+}
+
+// ─── Valid connections ───────────────────────────────────────────
+
+describe("checkInvalidConnections - valid", () => {
+  it("accepts a correct output→input connection with matching types", () => {
+    const issues = checkInvalidConnections(
+      [node("e", "emotion-analyzer"), node("m", "motion-trigger")],
+      [conn("c", "e", "expression", "m", "trigger")],
+      manifestMap(emotion, motion),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("accepts a legacy snake_case output port present in the manifest (dev state)", () => {
+    const issues = checkInvalidConnections(
+      [node("l", "lip-sync"), node("t", "voicevox-tts")],
+      // lip-sync.mouth_values (array) → would mismatch audio; use duration→nothing.
+      [conn("c", "l", "duration", "t", "text")],
+      manifestMap(lipSync, ttsAudio),
+    );
+    // duration(number) → text(string): type mismatch warning, but no error.
+    expect(issues.filter((i) => i.level === "error")).toEqual([]);
+  });
+});
+
+// ─── Reversed direction ──────────────────────────────────────────
+
+describe("checkInvalidConnections - reversed direction", () => {
+  it("flags an OUTPUT→OUTPUT connection (source uses an input, target uses an output) as errors", () => {
+    // emotion.expression (output) → motion.expression (output) — the exact bug.
+    const issues = checkInvalidConnections(
+      [node("e", "emotion-analyzer"), node("m", "motion-trigger")],
+      [conn("c", "e", "expression", "m", "expression")],
+      manifestMap(emotion, motion),
+    );
+    const errors = issues.filter((i) => i.level === "error");
+    // target side: 'expression' is an output of motion-trigger, not an input.
+    expect(errors.length).toBe(1);
+    expect(errors[0].message).toContain("入力ポートへ接続してください");
+  });
+
+  it("flags source endpoint that points at an input port", () => {
+    // motion.trigger is an INPUT; using it as a source is reversed.
+    const issues = checkInvalidConnections(
+      [node("m", "motion-trigger"), node("a2", "emotion-analyzer")],
+      [conn("c", "m", "trigger", "a2", "text")],
+      manifestMap(motion, emotion),
+    );
+    const errors = issues.filter((i) => i.level === "error");
+    expect(errors.length).toBe(1);
+    expect(errors[0].message).toContain("出力ポートから接続してください");
+  });
+});
+
+// ─── Non-existent ports ──────────────────────────────────────────
+
+describe("checkInvalidConnections - non-existent ports", () => {
+  it("flags a non-existent output port", () => {
+    const issues = checkInvalidConnections(
+      [node("e", "emotion-analyzer"), node("m", "motion-trigger")],
+      [conn("c", "e", "nope", "m", "trigger")],
+      manifestMap(emotion, motion),
+    );
+    const errors = issues.filter((i) => i.level === "error");
+    expect(errors.length).toBe(1);
+    expect(errors[0].message).toContain("出力ポート「nope」が存在しません");
+  });
+
+  it("flags a non-existent input port", () => {
+    const issues = checkInvalidConnections(
+      [node("e", "emotion-analyzer"), node("m", "motion-trigger")],
+      [conn("c", "e", "expression", "m", "nope")],
+      manifestMap(emotion, motion),
+    );
+    const errors = issues.filter((i) => i.level === "error");
+    expect(errors.length).toBe(1);
+    expect(errors[0].message).toContain("入力ポート「nope」が存在しません");
+  });
+});
+
+// ─── Type mismatch ───────────────────────────────────────────────
+
+describe("checkInvalidConnections - type mismatch", () => {
+  it("warns on mismatched known port types", () => {
+    // emotion.intensity (number) → motion.trigger (any) is compatible; use a
+    // string→number mismatch: emotion.expression (string) → a number input.
+    const numberSink = manifest("num-sink", "Number Sink", [
+      { id: "value", type: "number" },
+    ]);
+    const issues = checkInvalidConnections(
+      [node("e", "emotion-analyzer"), node("n", "num-sink")],
+      [conn("c", "e", "expression", "n", "value")],
+      manifestMap(emotion, numberSink),
+    );
+    const warnings = issues.filter((i) => i.level === "warning");
+    expect(warnings.length).toBe(1);
+    expect(warnings[0].message).toContain("型が一致しません");
+    expect(issues.filter((i) => i.level === "error")).toEqual([]);
+  });
+
+  it("does not warn when the source type is 'any'", () => {
+    const issues = checkInvalidConnections(
+      [node("m", "motion-trigger"), node("e", "emotion-analyzer")],
+      // motion.trigger is input; use motion's passthrough? motion has expression(string).
+      // emotion.text input is string. expression(string)→text(string) ok.
+      [conn("c", "m", "expression", "e", "text")],
+      manifestMap(motion, emotion),
+    );
+    expect(issues).toEqual([]);
+  });
+});
+
+// ─── No-port (event-driven) node ─────────────────────────────────
+
+describe("checkInvalidConnections - no-port node", () => {
+  it("warns (not errors) for connections into avatar-configuration and dedupes per node", () => {
+    const issues = checkInvalidConnections(
+      [node("e", "emotion-analyzer"), node("av", "avatar-configuration")],
+      [
+        conn("c1", "e", "expression", "av", "expression"),
+        conn("c2", "e", "intensity", "av", "intensity"),
+      ],
+      manifestMap(emotion, avatar),
+    );
+    expect(issues.filter((i) => i.level === "error")).toEqual([]);
+    const warnings = issues.filter((i) => i.level === "warning");
+    // one warning for the avatar node despite two connections
+    expect(warnings.length).toBe(1);
+    expect(warnings[0].nodeId).toBe("av");
+    expect(warnings[0].message).toContain("入出力ポートを持たない");
+  });
+});
+
+// ─── Dynamic input node ──────────────────────────────────────────
+
+describe("checkInvalidConnections - dynamic inputs", () => {
+  it("skips target-input checks for nodes with prompt-builder config", () => {
+    // a dynamic prompt-section input id that is not in the static manifest
+    const issues = checkInvalidConnections(
+      [node("e", "emotion-analyzer"), node("llm", "openai-llm")],
+      [conn("c", "e", "text", "llm", "userMessage")],
+      manifestMap(emotion, openaiLlm),
+    );
+    // userMessage is not a manifest input but must NOT be flagged.
+    expect(issues).toEqual([]);
+  });
+});
+
+// ─── Dangling connection ─────────────────────────────────────────
+
+describe("checkInvalidConnections - dangling", () => {
+  it("errors when a connection references a missing node", () => {
+    const issues = checkInvalidConnections(
+      [node("e", "emotion-analyzer")],
+      [conn("c", "e", "expression", "ghost", "trigger")],
+      manifestMap(emotion, motion),
+    );
+    const errors = issues.filter((i) => i.level === "error");
+    expect(errors.length).toBe(1);
+    expect(errors[0].message).toContain("存在しないノード");
+  });
+});
+
+// ─── Unknown manifest / unknown types ────────────────────────────
+
+describe("checkInvalidConnections - tolerant cases", () => {
+  it("skips endpoints whose node has no manifest", () => {
+    const issues = checkInvalidConnections(
+      [node("x", "custom-unknown"), node("y", "custom-unknown")],
+      [conn("c", "x", "out", "y", "in")],
+      new Map(), // no manifests
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("treats unmodeled port types as compatible (no warning)", () => {
+    const chat = manifest(
+      "chat",
+      "Chat",
+      [],
+      [{ id: "message", type: "Message" }],
+    );
+    const issues = checkInvalidConnections(
+      [node("c1", "chat"), node("llm", "openai-llm")],
+      [conn("c", "c1", "message", "llm", "prompt")],
+      manifestMap(chat, openaiLlm),
+    );
+    // openai-llm has dynamic inputs → target side skipped; source 'message' is a
+    // real output of chat → no error/warning.
+    expect(issues).toEqual([]);
+  });
+});
+
+// ─── Wiring through validateWorkflowSync ─────────────────────────
+
+describe("validateWorkflowSync - invalid connection wiring", () => {
+  it("surfaces a reversed-direction connection as an error", () => {
+    const issues = validateWorkflowSync(
+      {
+        nodes: [node("e", "emotion-analyzer"), node("m", "motion-trigger")],
+        connections: [conn("c", "e", "expression", "m", "expression")],
+      },
+      manifestMap(emotion, motion),
+    );
+    const errors = issues.filter((i) => i.level === "error");
+    expect(errors.some((e) => e.message.includes("入力ポートへ接続してください"))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## 概要

ノード接続のポート整合性を検証する `checkInvalidConnections` を validator に追加します。

### 背景（なぜ必要か）

従来、接続のポート**方向・存在・型**は実行時にも検証時にも一切チェックされていませんでした：

- `executor.ts` の `getNodeInputs` は、接続元の出力ポートが見つからないと**上流の出力オブジェクト全体を黙って下流に渡す**フォールバックがあり、不正接続でもエラーにならない。
- エディタの `isValidConnection` は**型のみ**判定で未知ポートは許可。さらに API / インポート / DB 直挿し経由の接続には無力。
- 結果として「出力ポート→出力ポート」「存在しないポートへの接続」「型不一致」が誰にも検出されず、サイレントにデータフローが壊れていた（既存テンプレートにも avatar への no-op 接続が存在）。

## 変更内容

`apps/server-ts/src/engine/connection-integrity.ts`（新規）を追加し、`validateWorkflow` / `validateWorkflowSync` から呼び出す。

### 検出内容と重大度

| 内容 | 重大度 |
|------|--------|
| 接続元が出力ポートでない / 存在しない（出力→出力の方向違反を含む） | **error** |
| 接続先が入力ポートでない / 存在しない（入力→入力の方向違反を含む） | **error** |
| 存在しないノードを参照する宙吊り接続 | **error** |
| 両端の型が非互換（`arePortTypesCompatible` 準拠） | warning |
| ポートを持たないノード（avatar-configuration 等イベント駆動）への接続 | warning（no-op） |

`error` は実行をブロック、`warning` はブロックしない（`/validate` の `valid = errors.length === 0`）。

### 誤検出回避

- manifest 未取得のノードはスキップ
- **動的入力ノード**（config に `prompt-builder` / `input-list` を持つ openai-llm・groq-llm・mistral-llm・text-transform）の入力側はスキップ（これらの入力は config から動的生成され manifest に無い。`Canvas.tsx` の動的ポート生成と同期）
- ポートを持たない側は「未記述」として扱い error にしない（純粋ソース/シンクノード・部分的 manifest を許容）
- 未モデル型（`Message` 等）は互換扱い

## テスト計画

- [x] `bun run typecheck`（server）通過
- [x] `tests/engine/connection-integrity.test.ts` に14ケース追加（方向違反・存在しないポート・型不一致・no-portノード・動的入力・宙吊り接続・寛容ケース）
- [x] 全133テスト通過（既存 validator テストの非回帰確認）
- [x] 実データ実証:
  - 実テンプレ `simple-vtuber` → error 0 / warning 1（avatar no-op のみ、誤検出なし）
  - 出力→出力バグ（`emotion.expression → motion.expression`）→ **error 検出**

## 補足

- 旧 snake_case ポートIDのエイリアス解決（#122 由来の `resolvePortId`）に対応できるよう、`checkInvalidConnections` は任意の `resolvePortId` を受け取れる設計にしてある（dev には alias 表が無いため既定は恒等関数）。#122 マージ後に validator 側で配線すれば整合する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
