### PR TITLE
refactor: プラグイン設定キー名をcamelCaseに統一

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ audio_output/
 
 # Specs (private)
 SPEC.md
+
+# Codex local config (contains local secrets — never commit)
+.codex/

--- a/apps/server-ts/src/engine/executor.ts
+++ b/apps/server-ts/src/engine/executor.ts
@@ -328,9 +328,7 @@ export class WorkflowExecutor {
     if (avatarConfig.renderer !== "vtube-studio") return;
 
     const port = (avatarConfig.vtubePort ?? avatarConfig.vtube_port ?? 8001) as number;
-    const mouthParam = (avatarConfig.vtubeMouthParam ??
-      avatarConfig.vtube_mouth_param ??
-      "MouthOpen") as string;
+    const mouthParam = (avatarConfig.vtubeMouthParam ?? avatarConfig.vtube_mouth_param ?? "MouthOpen") as string;
 
     let expressionMap: Record<string, string> | undefined;
     const rawMap = avatarConfig.vtubeExpressionMap ?? avatarConfig.vtube_expression_map;

--- a/apps/server-ts/src/engine/port-aliases.ts
+++ b/apps/server-ts/src/engine/port-aliases.ts
@@ -1,8 +1,8 @@
 /**
- * Legacy port-ID aliases for the snake_case → camelCase config-naming refactor.
- * Workflows saved before the rename still reference the old port IDs in their
- * connections, so old → new resolution lets those workflows keep working
- * without re-saving them.
+ * Legacy port-ID aliases for the snake_case → camelCase config-naming refactor
+ * (issue #104). Workflows saved before the rename still reference the old port
+ * IDs in their connections, so old → new resolution lets those workflows keep
+ * working without re-saving them.
  *
  * Shared by the executor (to route node inputs correctly) and the validator /
  * connection-integrity check (to avoid false "unconnected input" warnings and

--- a/apps/server-ts/src/engine/validator.ts
+++ b/apps/server-ts/src/engine/validator.ts
@@ -208,10 +208,13 @@ function checkUnconnectedInputs(
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
-  // Build a set of connected input ports: "nodeId:portId"
+  // Build a set of connected input ports: "nodeId:portId".
+  // Resolve legacy snake_case port IDs (issue #104) the same way the executor
+  // does, so a pre-rename connection (e.g. scene_name) is not flagged as
+  // unconnected against the manifest's new camelCase input id.
   const connectedInputs = new Set<string>();
   for (const conn of connections) {
-    connectedInputs.add(`${conn.to.nodeId}:${conn.to.port}`);
+    connectedInputs.add(`${conn.to.nodeId}:${resolvePortId(conn.to.port)}`);
   }
 
   for (const node of nodes) {

--- a/apps/server-ts/src/websocket/handler.ts
+++ b/apps/server-ts/src/websocket/handler.ts
@@ -173,8 +173,11 @@ function setupWorkflowCallbacks(workflowId: string): void {
         viseme: event.payload.viseme,
       });
     } else if (event.type === "avatar.motion") {
+      // Forward both the new camelCase motionUrl (primary after issue #104)
+      // and the legacy motion field; consumers read `motionUrl || motion`.
       wsBroadcaster.broadcast(workflowId, "avatar.motion", {
         motion: event.payload.motion ?? "",
+        motionUrl: event.payload.motionUrl ?? "",
       });
     } else if (event.type === "avatar.update") {
       wsBroadcaster.broadcast(workflowId, "avatar.update", event.payload);

--- a/apps/web/app/(editor)/editor/[id]/client-page.tsx
+++ b/apps/web/app/(editor)/editor/[id]/client-page.tsx
@@ -149,7 +149,7 @@ export default function EditorPage() {
   // Handle motion selection from library
   const handleMotionSelect = useCallback((motion: Motion) => {
     updateAvatarState({ motion: motion.url });
-    emit('avatar.motion', { motion_url: motion.url });
+    emit('avatar.motion', { motionUrl: motion.url });
   }, [emit, updateAvatarState]);
 
   // Handle expression change from presets

--- a/apps/web/app/(editor)/preview/[id]/client-page.tsx
+++ b/apps/web/app/(editor)/preview/[id]/client-page.tsx
@@ -156,7 +156,7 @@ export default function PreviewPage() {
             setAvatarState((prev) => ({ ...prev, mouthOpen: rest.value }));
             break;
           case 'avatar.motion':
-            setAvatarState((prev) => ({ ...prev, motion: rest.motion }));
+            setAvatarState((prev) => ({ ...prev, motion: rest.motionUrl || rest.motion }));
             break;
           case 'avatar.lookAt':
             setAvatarState((prev) => ({ ...prev, lookAt: rest }));

--- a/apps/web/components/panels/NodeSettings.tsx
+++ b/apps/web/components/panels/NodeSettings.tsx
@@ -2009,9 +2009,7 @@ export default function NodeSettings() {
 
   useEffect(() => {
     if (selectedNode) {
-      setLocalConfig(
-        normalizeLegacyConfig(selectedNode.type, selectedNode.config || {}),
-      );
+      setLocalConfig(normalizeLegacyConfig(selectedNode.type, selectedNode.config || {}));
       setShowOverrides(false);
 
       // Fetch VOICEVOX speakers if this is a voicevox-tts node

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## 概要

プラグインの `manifest.json` における設定キー名（config keys）がsnake_caseとcamelCaseで混在していた問題を修正し、JS/TSの慣例に合わせてcamelCaseに統一しました。

### 変更範囲

- **プラグイン**: 8プラグインの `manifest.json` と `node.ts`（camelCase + snake_caseフォールバック）
- **フロントエンド**: NodeSettings.tsx（LEGACY_KEY_MAP + normalizeLegacyConfig）、overlay/editor/preview
- **サーバー**: executor.ts（VTube Studio設定フォールバック）、port-aliases.ts（共有モジュール化）
- **WebSocket handler**: avatar.motion の motionUrl 転送漏れを修正
- **バリデータ**: 旧snake_caseポートIDの誤警告を解消
- **テンプレート**: 全7テンプレートJSON
- **ドキュメント**: api-reference.md, api-reference.ja.md

## テスト計画

- [x] 全133テストがパス（`bun test`）
- [x] エディターでノードの設定パネルが正しく表示・保存されること
- [x] ワークフロー実行が正常に動作すること

closes #104

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>