### PR TITLE
fix: グローバル設定の保存後にダイアログを自動で閉じる

### DIFF
--- a/apps/web/components/ui/SettingsModal.tsx
+++ b/apps/web/components/ui/SettingsModal.tsx
@@ -153,6 +153,7 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
     setSaving(false);
     if (ok) {
       toast.success(t('globalSettings.saved'));
+      onClose();
     } else {
       toast.error(t('globalSettings.saveError'));
     }


### PR DESCRIPTION
## 概要

- グローバル設定ダイアログで「保存」成功後、ダイアログを自動で閉じるようにした

## 変更

- `SettingsModal.tsx` の `handleSave` で保存成功時に `onClose()` を呼び出す（1行追加）

## テスト計画

- [ ] グローバル設定を開く → 値を変更 → 保存 → ダイアログが自動で閉じること
- [ ] 保存失敗時（サーバー停止中等）はダイアログが閉じないこと

closes #191

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>