### PR TITLE
fix: ワークフローロックのレースコンディションを修正

### DIFF
--- a/apps/server-ts/src/engine/executor.ts
+++ b/apps/server-ts/src/engine/executor.ts
@@ -466,9 +466,13 @@ export class WorkflowExecutor {
   // ─── Workflow Lock ──────────────
 
   private async withWorkflowLock<T>(workflowId: string, fn: () => Promise<T>): Promise<T> {
-    // Wait for any existing operation on this workflow to complete
-    while (this.workflowLocks.has(workflowId)) {
-      await this.workflowLocks.get(workflowId);
+    // Wait for any existing operation on this workflow to complete.
+    // Capture the promise before awaiting to avoid a race where the lock
+    // is deleted between has() and get().
+    let existing = this.workflowLocks.get(workflowId);
+    while (existing) {
+      await existing;
+      existing = this.workflowLocks.get(workflowId);
     }
 
     let resolve: (() => void) | undefined;


### PR DESCRIPTION
## 概要

- `withWorkflowLock` で `has()` と `get()` の間にロックが削除されるレースコンディションを修正

## #149 の5項目の対応状況

| 項目 | 状態 |
|---|---|
| Graceful shutdown | 既に実装済み（`index.ts` の `gracefulShutdown`） |
| DB close | 既に実装済み（`closeDb()` が shutdown から呼ばれている） |
| **Lock spin race** | **本PRで修正** |
| startWorkflow fire-and-forget | 既に修正済み（`.catch` でステータスに記録） |
| 不正JSONサイレント処理 | 既に修正済み（Zod バリデーション + 400 返却） |

## テスト計画

- [x] 全133テストがパス

closes #149

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>