### PR TITLE
feat: ノード設定をComfyUI式インライン編集に移行（Phase 1）

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aituber-flow/desktop",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aituber-flow/desktop",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/web/components/editor/Canvas.tsx
+++ b/apps/web/components/editor/Canvas.tsx
@@ -107,7 +107,7 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
   } = useWorkflowStore();
 
   const { nodeDisplayMode, setNodeDisplayMode, searchVisible, searchQuery } = useUIPreferencesStore();
-  const { getPluginColor, getPluginLabel, getPluginById, getPluginInputs, getPluginOutputs } = usePluginStore();
+  const { getPluginColor, getPluginLabel, getPluginById, getPluginInputs, getPluginOutputs, getPluginConfig } = usePluginStore();
   const { setDragging, clearDragging } = useDragStateStore();
 
   // State for the "drop-on-canvas" compatible node suggestion panel
@@ -290,6 +290,8 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
           ? mapPluginCategoryToLegacy(plugin.category)
           : getNodeCategory(node.type);
 
+        const pluginConfig = getPluginConfig(node.type);
+
         return {
           id: node.id,
           type: reactFlowNodeType,
@@ -299,6 +301,7 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
             type: node.type,
             category,
             config: node.config,
+            pluginConfig,
             inputs: nodeInputs,
             outputs: nodeOutputs,
             isReachable,
@@ -312,7 +315,7 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
         };
       });
     },
-    [workflowNodes, reachableNodes, hasStartNode, onRunWorkflow, getPluginLabel, getPluginById, getPluginInputs, getPluginOutputs, searchMatchIds, nodeStatuses]
+    [workflowNodes, reachableNodes, hasStartNode, onRunWorkflow, getPluginLabel, getPluginById, getPluginInputs, getPluginOutputs, getPluginConfig, searchMatchIds, nodeStatuses]
   );
 
   // Apply selection in a cheap second pass. Unchanged nodes keep their object

--- a/apps/web/components/editor/CustomNode.tsx
+++ b/apps/web/components/editor/CustomNode.tsx
@@ -10,12 +10,15 @@ import { useLocaleStore } from '@/stores/localeStore';
 import { type PortDefinition, PORT_TYPE_COLORS, PORT_TYPE_LABELS, arePortTypesCompatible, type PortType } from '@/lib/portTypes';
 import { useDragStateStore } from '@/stores/dragStateStore';
 import { renderIcon } from '@/lib/icons';
+import { evaluateShowWhen } from '@/lib/configUtils';
+import type { ConfigField } from '@/lib/types';
 
 export interface CustomNodeData extends Record<string, unknown> {
   label: string;
   type: string;
   category: 'input' | 'process' | 'output' | 'control';
   config: Record<string, unknown>;
+  pluginConfig?: Record<string, import('@/lib/types').ConfigField>;
   inputs?: PortDefinition[];
   outputs?: PortDefinition[];
   isReachable?: boolean;  // Whether this node is reachable from Start
@@ -75,8 +78,150 @@ function formatDuration(ms: number | undefined): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
+// Inline fields component for ComfyUI-style editing directly on nodes
+function InlineFields({
+  config,
+  pluginConfig,
+  onConfigChange,
+  accentColor,
+}: {
+  config: Record<string, unknown>;
+  pluginConfig: Record<string, ConfigField>;
+  onConfigChange: (key: string, value: unknown) => void;
+  accentColor: string;
+}) {
+  const inlineFields = Object.entries(pluginConfig).filter(
+    ([, field]) => field.inline && !field.dynamic
+  );
+  if (inlineFields.length === 0) return null;
+
+  const barBg = 'rgba(255,255,255,0.07)';
+
+  return (
+    <div className="flex flex-col gap-[3px] mt-1">
+      {inlineFields.map(([key, field]) => {
+        if (!evaluateShowWhen(field.showWhen, config)) return null;
+
+        const value = config[key] ?? field.default;
+
+        if (field.type === 'select' && field.options) {
+          const options = field.options.map((opt) =>
+            typeof opt === 'string' ? { label: opt, value: opt } : opt
+          );
+          const selectedLabel = options.find(o => String(o.value) === String(value))?.label || String(value);
+          return (
+            <div key={key} className="nodrag nopan relative" style={{ background: barBg, borderRadius: '4px' }}>
+              <div className="flex items-center justify-between px-2 h-[26px]">
+                <span className="text-[10px] text-white/45 select-none">{field.label}</span>
+                <span className="text-[10px] text-white/75 select-none">{selectedLabel}</span>
+              </div>
+              <select
+                className="nodrag nopan absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                value={String(value ?? '')}
+                onChange={(e) => onConfigChange(key, e.target.value)}
+                onClick={(e) => e.stopPropagation()}
+              >
+                {options.map((opt) => (
+                  <option key={String(opt.value)} value={String(opt.value)}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          );
+        }
+
+        if (field.type === 'number') {
+          const numValue = typeof value === 'number' ? value : Number(value) || 0;
+          const min = field.min ?? 0;
+          const max = field.max ?? 100;
+          const step = max - min <= 2 ? 0.01 : max - min <= 10 ? 0.1 : 1;
+          const pct = Math.max(0, Math.min(100, ((numValue - min) / (max - min)) * 100));
+          return (
+            <div key={key} className="nodrag nopan relative" style={{ background: barBg, borderRadius: '4px', overflow: 'hidden' }}>
+              <div
+                className="absolute left-0 top-0 bottom-0 pointer-events-none"
+                style={{ width: `${pct}%`, background: `${accentColor}50`, transition: 'width 0.1s' }}
+              />
+              <div className="relative flex items-center justify-between px-2 h-[26px]">
+                <span className="text-[10px] text-white/45 select-none">{field.label}</span>
+                <span className="text-[10px] text-white/75 tabular-nums select-none">
+                  {numValue % 1 === 0 ? numValue : numValue.toFixed(2)}
+                </span>
+              </div>
+              <input
+                type="range"
+                className="nodrag nopan absolute inset-0 w-full h-full opacity-0 cursor-ew-resize"
+                min={min}
+                max={max}
+                step={step}
+                value={numValue}
+                onChange={(e) => onConfigChange(key, parseFloat(e.target.value))}
+                onClick={(e) => e.stopPropagation()}
+              />
+            </div>
+          );
+        }
+
+        if (field.type === 'boolean') {
+          const boolValue = Boolean(value);
+          return (
+            <div key={key}>
+              <button
+                className="nodrag nopan w-full relative text-left"
+                style={{ background: barBg, borderRadius: '4px', overflow: 'hidden' }}
+                onClick={(e) => { e.stopPropagation(); onConfigChange(key, !boolValue); }}
+              >
+                {boolValue && (
+                  <div className="absolute left-0 top-0 bottom-0 w-full pointer-events-none" style={{ background: `${accentColor}20` }} />
+                )}
+                <div className="relative flex items-center justify-between px-2 h-[26px]">
+                  <span className="text-[10px] text-white/45 select-none">{field.label}</span>
+                  <div
+                    className="relative flex-shrink-0 rounded-full transition-colors"
+                    style={{ width: '20px', height: '11px', background: boolValue ? accentColor : 'rgba(255,255,255,0.2)' }}
+                  >
+                    <span
+                      className="absolute top-[1.5px] rounded-full bg-white transition-transform"
+                      style={{ width: '8px', height: '8px', transform: boolValue ? 'translateX(10.5px)' : 'translateX(1.5px)' }}
+                    />
+                  </div>
+                </div>
+              </button>
+            </div>
+          );
+        }
+
+        if (field.type === 'string') {
+          return (
+            <div key={key} className="nodrag nopan relative" style={{ background: barBg, borderRadius: '4px' }}>
+              <div className="flex items-center px-2 h-[26px] gap-2">
+                <span className="text-[10px] text-white/45 flex-shrink-0 select-none">{field.label}</span>
+                <input
+                  type="text"
+                  className="nodrag nopan bg-transparent text-[10px] text-white/75 outline-none text-right flex-1 min-w-0"
+                  value={String(value ?? '')}
+                  placeholder={field.placeholder}
+                  onChange={(e) => onConfigChange(key, e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                />
+              </div>
+            </div>
+          );
+        }
+
+        return null;
+      })}
+    </div>
+  );
+}
+
 function CustomNode({ id, data, selected }: CustomNodeProps) {
   const selectNode = useWorkflowStore((s) => s.selectNode);
+  const updateNode = useWorkflowStore((s) => s.updateNode);
+  const onInlineConfigChange = useCallback((key: string, value: unknown) => {
+    updateNode(id, { config: { ...data.config, [key]: value } });
+  }, [id, data.config, updateNode]);
   const status = data.nodeStatus;
   const { getPluginColor, getPluginBgColor, getPluginIcon, getPluginById } = usePluginStore();
   const { nodeDisplayMode, collapsedNodeIds, toggleNodeCollapse } = useUIPreferencesStore();
@@ -933,6 +1078,18 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
           {getStatusText()}
         </div>
 
+        {/* Inline fields */}
+        {data.pluginConfig && (
+          <div className="px-3 pb-2">
+            <InlineFields
+              config={data.config}
+              pluginConfig={data.pluginConfig}
+              onConfigChange={onInlineConfigChange}
+              accentColor={config.color}
+            />
+          </div>
+        )}
+
         <StatusIndicator />
       </div>
     );
@@ -1035,6 +1192,15 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
       <div className="text-[10px] text-white/40 truncate">
         {getStatusText()}
       </div>
+
+      {/* Inline fields */}
+      {data.pluginConfig && (
+        <InlineFields
+          config={data.config}
+          pluginConfig={data.pluginConfig}
+          onConfigChange={onInlineConfigChange}
+        />
+      )}
 
       <StatusIndicator />
     </div>

--- a/apps/web/lib/configUtils.ts
+++ b/apps/web/lib/configUtils.ts
@@ -50,7 +50,7 @@ function mapFieldType(manifestType: ConfigField['type']): NodeField['type'] {
 export function manifestConfigToNodeFields(
   config: Record<string, ConfigField>
 ): NodeField[] {
-  return Object.entries(config).map(([key, field]) => ({
+  return Object.entries(config).filter(([, field]) => !field.inline).map(([key, field]) => ({
     key,
     type: mapFieldType(field.type),
     label: field.label,

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -147,6 +147,7 @@ export interface ConfigField {
   dynamic?: boolean;
   dependsOn?: string;
   showWhen?: ShowWhenCondition;
+  inline?: boolean;
 }
 
 export type ShowWhenCondition =

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aituber-flow-web",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aituber-flow-web",
-      "version": "2.3.2",
+      "version": "2.4.0",
       "dependencies": {
         "@pixiv/three-vrm": "^3.4.5",
         "@pixiv/three-vrm-animation": "^3.4.5",

--- a/plugins/aivis-tts/manifest.json
+++ b/plugins/aivis-tts/manifest.json
@@ -72,7 +72,8 @@
       "description": "Speech speed (0.5-2.0)",
       "default": 1,
       "min": 0.5,
-      "max": 2
+      "max": 2,
+      "inline": true
     },
     "pitchScale": {
       "type": "number",

--- a/plugins/anthropic-llm/manifest.json
+++ b/plugins/anthropic-llm/manifest.json
@@ -51,6 +51,7 @@
       "label": "Model",
       "description": "Claude model to use",
       "default": "claude-sonnet-4-20250514",
+      "inline": true,
       "options": [
         { "label": "Claude Opus 4", "value": "claude-opus-4-20250514" },
         { "label": "Claude Sonnet 4", "value": "claude-sonnet-4-20250514" },
@@ -81,7 +82,8 @@
       "description": "Sampling temperature (0-1)",
       "default": 0.7,
       "min": 0,
-      "max": 1
+      "max": 1,
+      "inline": true
     }
   }
 }

--- a/plugins/audio-player/manifest.json
+++ b/plugins/audio-player/manifest.json
@@ -62,7 +62,8 @@
       "description": "Playback volume (0.0 - 1.0)",
       "default": 1,
       "min": 0,
-      "max": 1
+      "max": 1,
+      "inline": true
     },
     "outputDevice": {
       "type": "select",

--- a/plugins/coeiroink-tts/manifest.json
+++ b/plugins/coeiroink-tts/manifest.json
@@ -73,7 +73,8 @@
       "description": "Speech speed (0.5-2.0)",
       "default": 1.0,
       "min": 0.5,
-      "max": 2.0
+      "max": 2.0,
+      "inline": true
     },
     "volumeScale": {
       "type": "number",

--- a/plugins/console-output/manifest.json
+++ b/plugins/console-output/manifest.json
@@ -43,6 +43,7 @@
       "label": "Log Level",
       "description": "The log level for output messages",
       "default": "info",
+      "inline": true,
       "options": [
         {"label": "Info", "value": "info"},
         {"label": "Debug", "value": "debug"},

--- a/plugins/delay/manifest.json
+++ b/plugins/delay/manifest.json
@@ -44,7 +44,8 @@
       "description": "Delay time in milliseconds",
       "default": 1000,
       "min": 0,
-      "max": 60000
+      "max": 60000,
+      "inline": true
     },
     "randomize": {
       "type": "boolean",

--- a/plugins/emotion-analyzer/manifest.json
+++ b/plugins/emotion-analyzer/manifest.json
@@ -53,6 +53,7 @@
       "type": "select",
       "label": "Analysis Method",
       "description": "Method to use for emotion detection",
+      "inline": true,
       "options": [
         {
           "label": "LLM-based (Recommended)",

--- a/plugins/google-llm/manifest.json
+++ b/plugins/google-llm/manifest.json
@@ -51,6 +51,7 @@
       "label": "Model",
       "description": "Gemini model to use",
       "default": "gemini-2.5-flash-preview-05-20",
+      "inline": true,
       "options": [
         { "label": "Gemini 3 Pro Preview", "value": "gemini-3-pro-preview" },
         { "label": "Gemini 3 Flash Preview", "value": "gemini-3-flash-preview" },
@@ -78,7 +79,8 @@
       "description": "Sampling temperature (0-1)",
       "default": 0.7,
       "min": 0,
-      "max": 1
+      "max": 1,
+      "inline": true
     }
   }
 }

--- a/plugins/groq-llm/manifest.json
+++ b/plugins/groq-llm/manifest.json
@@ -51,6 +51,7 @@
       "label": "Model",
       "description": "The model to use for inference",
       "default": "llama-3.3-70b-versatile",
+      "inline": true,
       "options": [
         { "label": "Llama 3.3 70B Versatile", "value": "llama-3.3-70b-versatile" },
         { "label": "Llama 3.1 8B Instant", "value": "llama-3.1-8b-instant" },
@@ -76,7 +77,8 @@
       "description": "Controls randomness. Higher = more creative, Lower = more focused (0-2)",
       "default": 0.7,
       "min": 0,
-      "max": 2
+      "max": 2,
+      "inline": true
     },
     "maxTokens": {
       "type": "number",

--- a/plugins/mistral-llm/manifest.json
+++ b/plugins/mistral-llm/manifest.json
@@ -51,6 +51,7 @@
       "label": "Model",
       "description": "The Mistral model to use",
       "default": "mistral-small-latest",
+      "inline": true,
       "options": [
         { "label": "Mistral Large", "value": "mistral-large-latest" },
         { "label": "Mistral Medium", "value": "mistral-medium-latest" },
@@ -77,7 +78,8 @@
       "description": "Controls randomness. Higher = more creative, Lower = more focused (0-2)",
       "default": 0.7,
       "min": 0,
-      "max": 2
+      "max": 2,
+      "inline": true
     },
     "maxTokens": {
       "type": "number",

--- a/plugins/ollama-llm/manifest.json
+++ b/plugins/ollama-llm/manifest.json
@@ -50,7 +50,8 @@
       "type": "string",
       "label": "Model",
       "description": "Model name (e.g., llama3.2, mistral, gemma2)",
-      "default": "llama3.2"
+      "default": "llama3.2",
+      "inline": true
     },
     "systemPrompt": {
       "type": "textarea",
@@ -64,7 +65,8 @@
       "description": "Sampling temperature (0-1)",
       "default": 0.7,
       "min": 0,
-      "max": 1
+      "max": 1,
+      "inline": true
     },
     "contextLength": {
       "type": "number",

--- a/plugins/openai-llm/manifest.json
+++ b/plugins/openai-llm/manifest.json
@@ -51,6 +51,7 @@
       "label": "Model",
       "description": "The GPT model to use",
       "default": "gpt-4o-mini",
+      "inline": true,
       "options": [
         { "label": "GPT-5.2", "value": "gpt-5.2" },
         { "label": "GPT-5.2 Codex", "value": "gpt-5.2-codex" },
@@ -136,7 +137,8 @@
       "description": "Controls randomness. Higher = more creative, Lower = more focused (0-2)",
       "default": 0.7,
       "min": 0,
-      "max": 2
+      "max": 2,
+      "inline": true
     },
     "maxTokens": {
       "type": "number",

--- a/plugins/openai-tts/manifest.json
+++ b/plugins/openai-tts/manifest.json
@@ -74,6 +74,7 @@
       "label": "Voice",
       "description": "Voice to use for speech",
       "default": "alloy",
+      "inline": true,
       "options": [
         { "label": "Alloy", "value": "alloy" },
         { "label": "Ash", "value": "ash" },
@@ -93,7 +94,8 @@
       "description": "Speech speed (0.25-4.0)",
       "default": 1,
       "min": 0.25,
-      "max": 4
+      "max": 4,
+      "inline": true
     },
     "instructions": {
       "type": "textarea",

--- a/plugins/sbv2-tts/manifest.json
+++ b/plugins/sbv2-tts/manifest.json
@@ -87,7 +87,8 @@
       "description": "Speech speed (0.5-2.0)",
       "default": 1.0,
       "min": 0.5,
-      "max": 2.0
+      "max": 2.0,
+      "inline": true
     },
     "sdpRatio": {
       "type": "number",

--- a/plugins/subtitle-display/manifest.json
+++ b/plugins/subtitle-display/manifest.json
@@ -93,7 +93,8 @@
       "description": "Font size in pixels",
       "default": 24,
       "min": 12,
-      "max": 72
+      "max": 72,
+      "inline": true
     },
     "fontColor": {
       "type": "string",

--- a/plugins/text-transform/manifest.json
+++ b/plugins/text-transform/manifest.json
@@ -43,6 +43,7 @@
       "label": "Operation",
       "description": "Transformation to apply",
       "default": "template",
+      "inline": true,
       "options": ["template", "uppercase", "lowercase", "trim", "replace", "split_first", "split_last", "length", "prefix", "suffix"]
     },
     "template": {

--- a/plugins/voicevox-tts/manifest.json
+++ b/plugins/voicevox-tts/manifest.json
@@ -72,7 +72,8 @@
       "description": "Speech speed (0.5-2.0)",
       "default": 1,
       "min": 0.5,
-      "max": 2
+      "max": 2,
+      "inline": true
     },
     "pitchScale": {
       "type": "number",


### PR DESCRIPTION
## 概要

ノード内に設定フィールドを直接埋め込み、ComfyUI式のインライン編集を実現。Phase 1 では主要なシンプルフィールド（select, number, boolean）をノード内に表示。

## 変更内容

- `ConfigField` に `inline` フラグを追加
- `CustomNode.tsx` にインラインフィールド描画（バー型ウィジェット）
- `Canvas.tsx` で `pluginConfig` を CustomNode に受け渡し
- `configUtils` で inline フィールドを右パネルから除外
- 16プラグインの主要フィールドに `inline: true` を設定

## Phase 2（別PR予定）

- 全フィールドをノード内に移行（サイドバー設定欄廃止）
- フィールドごとの ▶/▼ 折りたたみ
- textarea/password 等の複合フィールド対応

## テスト計画

- [x] 全133テストがパス
- [x] ESLint 0 errors, 0 warnings
- [x] ドロップダウン・スライダー・トグルが操作可能
- [x] 値変更が保存される
- [x] ノードドラッグが干渉しない（nodrag クラス）

closes #193

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>