### PR TITLE
fix: 検証フィードバック3件（音声キュー残留・ドラッグ性能・フィールド初期表示）

### DIFF
--- a/apps/web/components/editor/Canvas.tsx
+++ b/apps/web/components/editor/Canvas.tsx
@@ -108,7 +108,7 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
   } = useWorkflowStore();
 
   const { nodeDisplayMode, setNodeDisplayMode, searchVisible, searchQuery } = useUIPreferencesStore();
-  const { getPluginColor, getPluginLabel, getPluginById, getPluginInputs, getPluginOutputs, getPluginConfig } = usePluginStore();
+  const { getPluginColor, getPluginLabel, getPluginById, getPluginInputs, getPluginOutputs, getPluginConfig, isLoaded: pluginsLoaded } = usePluginStore();
   const { setDragging, clearDragging } = useDragStateStore();
 
   // State for the "drop-on-canvas" compatible node suggestion panel
@@ -300,6 +300,7 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
             category,
             config: node.config,
             pluginConfig,
+            pluginsLoaded,
             inputs: nodeInputs,
             outputs: nodeOutputs,
             isReachable,
@@ -313,7 +314,7 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
         };
       });
     },
-    [workflowNodes, reachableNodes, hasStartNode, onRunWorkflow, getPluginLabel, getPluginById, getPluginInputs, getPluginOutputs, getPluginConfig, searchMatchIds, nodeStatuses]
+    [workflowNodes, reachableNodes, hasStartNode, onRunWorkflow, getPluginLabel, getPluginById, getPluginInputs, getPluginOutputs, getPluginConfig, pluginsLoaded, searchMatchIds, nodeStatuses]
   );
 
   // Apply selection in a cheap second pass. Unchanged nodes keep their object
@@ -391,9 +392,12 @@ export default function Canvas({ onNodeSelect, onSave, onRunWorkflow }: CanvasPr
     (changes) => {
       onNodesChangeInternal(changes);
 
-      // Handle position changes
+      // Handle position changes. Store writes are skipped while dragging:
+      // each write rebuilds every node's data object and re-renders all
+      // nodes (now heavy with inline config fields). React Flow tracks the
+      // live position internally; persist to the store only on drop.
       changes.forEach((change) => {
-        if (change.type === 'position' && change.position) {
+        if (change.type === 'position' && change.position && !change.dragging) {
           setNodePosition(change.id, change.position);
         }
         if (change.type === 'remove') {

--- a/apps/web/components/editor/CustomNode.tsx
+++ b/apps/web/components/editor/CustomNode.tsx
@@ -19,6 +19,7 @@ export interface CustomNodeData extends Record<string, unknown> {
   category: 'input' | 'process' | 'output' | 'control';
   config: Record<string, unknown>;
   pluginConfig?: Record<string, import('@/lib/types').ConfigField>;
+  pluginsLoaded?: boolean; // False until the plugin registry fetch completes (config fields unavailable)
   inputs?: PortDefinition[];
   outputs?: PortDefinition[];
   isReachable?: boolean;  // Whether this node is reachable from Start
@@ -497,6 +498,18 @@ function getValueSummary(field: ConfigField, value: unknown): string {
       return str.length > 20 ? str.slice(0, 20) + '...' : str;
     }
   }
+}
+
+// Placeholder shown while the plugin registry is still loading, so config
+// fields don't pop in after the node has already rendered.
+function ConfigFieldsSkeleton() {
+  return (
+    <div className="space-y-1 animate-pulse" aria-hidden="true">
+      <div className="h-[26px] rounded bg-white/5" />
+      <div className="h-[26px] rounded bg-white/5" />
+      <div className="h-[26px] rounded bg-white/5" />
+    </div>
+  );
 }
 
 // Collapsible node config fields component (Phase 2)
@@ -1685,6 +1698,11 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
             />
           </div>
         )}
+        {!data.pluginConfig && data.pluginsLoaded === false && (
+          <div className="px-3 pb-2">
+            <ConfigFieldsSkeleton />
+          </div>
+        )}
 
         <StatusIndicator />
       </div>
@@ -1800,6 +1818,7 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
           onOpenSettings={openSettings}
         />
       )}
+      {!data.pluginConfig && data.pluginsLoaded === false && <ConfigFieldsSkeleton />}
 
       <StatusIndicator />
     </div>

--- a/apps/web/hooks/useWebSocket.ts
+++ b/apps/web/hooks/useWebSocket.ts
@@ -152,6 +152,17 @@ export function useWebSocket(workflowId: string | null) {
       }
     }
 
+    // Drop everything queued and silence the current utterance. A new run
+    // (or an explicit stop) must not keep playing audio from the previous run.
+    function clearAudioPlayback() {
+      audioQueueRef.current = [];
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current = null;
+      }
+      setAvatarState((prev) => ({ ...prev, mouthOpen: 0 }));
+    }
+
     function playNextAudio() {
       const nextUrl = audioQueueRef.current.shift();
       if (!nextUrl) {
@@ -198,11 +209,13 @@ export function useWebSocket(workflowId: string | null) {
           break;
 
         case 'execution.started':
+          clearAudioPlayback();
           setExecuting(true);
           addLog({ level: 'info', message: 'Workflow execution started' });
           break;
 
         case 'execution.stopped':
+          clearAudioPlayback();
           setExecuting(false);
           addLog({
             level: 'info',


### PR DESCRIPTION
## 概要

2026-06-10 の人間による動作検証で見つかった3件を修正。

### 1. 実行の再開始・停止で音声キューが残留する
- `useWebSocket.ts` に `clearAudioPlayback()` を追加し、`execution.started` / `execution.stopped` 受信時にキュー破棄＋再生中音声の停止＋口の開閉リセットを行う
- 症状: ワークフローを連続実行すると前回の実行でキューされた音声が鳴り続けていた

### 2. ノードドラッグが重くカクつく
- `Canvas.tsx` の `onNodesChange` で、ドラッグ中（`change.dragging === true`）はストアへの位置書き込みをスキップし、ドロップ時のみ保存
- 原因: 毎フレームのストア更新→全ノードのdata再構築→全インラインフィールドの再レンダリング（Phase 2でノードが重くなり顕在化）
- React Flow がドラッグ中の見た目上の位置を内部管理するため、表示は変わらず書き込みだけ減る

### 3. インラインフィールドが後からニュッと表示される
- プラグイン定義（`/api/plugins`）のロード完了前は、フィールド領域にスケルトン（パルスする3行のプレースホルダ）を表示
- `pluginStore.isLoaded` を `CustomNodeData.pluginsLoaded` として伝搬

## テスト計画

- [x] ローカルで `npm run build` 成功（型チェック込み）
- [x] ブラウザ検証: ドラッグ→ドロップ→Save→API上の position が更新されることを確認（保存の回帰なし）
- [x] ブラウザ検証: `/api/plugins` を4秒遅延させ、全ノードにスケルトンが表示→完了後に実フィールドへ差し替わることを確認
- [ ] 音声キューのクリアは VOICEVOX 環境での実機確認（レビュー後にユーザー検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)