### PR TITLE
feat: インラインフィールドに「グローバル設定を使用中」バッジを表示

### DIFF
--- a/apps/web/components/editor/CustomNode.tsx
+++ b/apps/web/components/editor/CustomNode.tsx
@@ -11,6 +11,8 @@ import { type PortDefinition, PORT_TYPE_COLORS, PORT_TYPE_LABELS, arePortTypesCo
 import { useDragStateStore } from '@/stores/dragStateStore';
 import { renderIcon } from '@/lib/icons';
 import { evaluateShowWhen } from '@/lib/configUtils';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { GLOBAL_SETTINGS_MAP } from '@/lib/globalSettingsMap';
 import type { ConfigField } from '@/lib/types';
 
 export interface CustomNodeData extends Record<string, unknown> {
@@ -514,12 +516,14 @@ function ConfigFieldsSkeleton() {
 
 // Collapsible node config fields component (Phase 2)
 function NodeConfigFields({
+  nodeType,
   config,
   pluginConfig,
   onConfigChange,
   accentColor,
   onOpenSettings,
 }: {
+  nodeType: string;
   config: Record<string, unknown>;
   pluginConfig: Record<string, ConfigField>;
   onConfigChange: (key: string, value: unknown) => void;
@@ -541,6 +545,22 @@ function NodeConfigFields({
     label: string;
     anchorRect: { top: number; left: number; right: number };
   } | null>(null);
+
+  // Global settings fallback: the engine fills empty fields (e.g. apiKey)
+  // from global settings — surface that so an empty field doesn't look broken
+  const { settings: globalSettings, loaded: globalSettingsLoaded, fetchSettings } = useSettingsStore();
+  useEffect(() => {
+    if (!globalSettingsLoaded) fetchSettings();
+  }, [globalSettingsLoaded, fetchSettings]);
+
+  const globalMapping = GLOBAL_SETTINGS_MAP[nodeType];
+  const globalKeyInUse = (key: string): string | undefined => {
+    const settingsKey = globalMapping?.[key];
+    if (!settingsKey) return undefined;
+    const local = config[key];
+    const isEmpty = local === undefined || local === null || local === '';
+    return isEmpty && globalSettings[settingsKey] ? settingsKey : undefined;
+  };
 
   if (allFields.length === 0) return null;
 
@@ -753,7 +773,14 @@ function NodeConfigFields({
 
         const isExpanded = !!expandedFields[key];
         const value = config[key] ?? field.default;
-        const summary = getValueSummary(field, value);
+        const usedGlobalKey = globalKeyInUse(key);
+        // When the engine falls back to a global setting, summarize THAT value
+        // (the plugin default shown otherwise would be wrong). Never reveal secrets.
+        const summary = usedGlobalKey
+          ? field.type === 'password'
+            ? ''
+            : getValueSummary(field, globalSettings[usedGlobalKey])
+          : getValueSummary(field, value);
 
         return (
           <div key={key} style={{ borderRadius: '4px', overflow: 'hidden' }}>
@@ -766,8 +793,17 @@ function NodeConfigFields({
             >
               <ToggleIcon expanded={isExpanded} />
               <span className="text-[10px] text-white/55 select-none flex-shrink-0">{field.label}</span>
-              {!isExpanded && (
-                <span className="text-[10px] text-white/60 select-none ml-auto truncate max-w-[60%] text-right">
+              {usedGlobalKey && (
+                <span
+                  className="text-[9px] px-1 py-px rounded select-none flex-shrink-0 ml-auto"
+                  style={{ background: 'rgba(255,255,255,0.12)', color: 'rgba(255,255,255,0.6)' }}
+                  title="ノード側が未設定のため、グローバル設定の値を使用しています（入力すると上書き）"
+                >
+                  グローバル
+                </span>
+              )}
+              {!isExpanded && summary && (
+                <span className={`text-[10px] text-white/60 select-none truncate max-w-[60%] text-right ${usedGlobalKey ? '' : 'ml-auto'}`}>
                   {summary}
                 </span>
               )}
@@ -1690,6 +1726,7 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
         {data.pluginConfig && (
           <div className="px-3 pb-2">
             <NodeConfigFields
+              nodeType={data.type}
               config={data.config}
               pluginConfig={data.pluginConfig}
               onConfigChange={onInlineConfigChange}
@@ -1811,6 +1848,7 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
       {/* Config fields */}
       {data.pluginConfig && (
         <NodeConfigFields
+          nodeType={data.type}
           config={data.config}
           pluginConfig={data.pluginConfig}
           onConfigChange={onInlineConfigChange}

--- a/apps/web/components/panels/NodeSettings.tsx
+++ b/apps/web/components/panels/NodeSettings.tsx
@@ -7,6 +7,7 @@ import { usePluginStore } from "@/stores/pluginStore";
 import api, { VoicevoxSpeaker, AnimationInfo, ModelInfo } from "@/lib/api";
 import { manifestConfigToNodeFields, evaluateShowWhen, normalizeOptions } from "@/lib/configUtils";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { GLOBAL_SETTINGS_MAP } from "@/lib/globalSettingsMap";
 import { LLM_MODEL_OPTIONS } from "@/lib/constants";
 import type { NodeField } from "@/lib/types";
 import { toast } from "@/stores/toastStore";
@@ -610,20 +611,9 @@ function PngExpressionMapField({
   );
 }
 
-// Global settings field mapping (mirrors server-side GLOBAL_SETTINGS_MAP)
-const GLOBAL_SETTINGS_MAP: Record<string, Record<string, string>> = {
-  "openai-llm": { apiKey: "openai.apiKey", model: "openai.model" },
-  "anthropic-llm": { apiKey: "anthropic.apiKey", model: "anthropic.model" },
-  "google-llm": { apiKey: "google.apiKey", model: "google.model" },
-  "ollama-llm": { host: "ollama.host", model: "ollama.model" },
-  "mistral-llm": { apiKey: "mistral.apiKey", model: "mistral.model" },
-  "groq-llm": { apiKey: "groq.apiKey", model: "groq.model" },
-  "voicevox-tts": { host: "voicevox.host" },
-  "coeiroink-tts": { host: "coeiroink.host" },
-  "sbv2-tts": { host: "sbv2.host" },
-  "aivis-tts": { host: "aivis.host" },
-  "openai-tts": { apiKey: "openai.apiKey" },
-};
+// Global settings field mapping moved to the shared module so the inline
+// node fields (CustomNode) and this panel stay in sync.
+// (mirrors server-side GLOBAL_SETTINGS_MAP)
 
 // LLM_MODEL_OPTIONS imported from @/lib/constants
 

--- a/apps/web/lib/globalSettingsMap.ts
+++ b/apps/web/lib/globalSettingsMap.ts
@@ -1,0 +1,20 @@
+/**
+ * Maps node types to their config fields and corresponding global setting keys.
+ * When a node's config field is empty, the engine fills it from global settings.
+ *
+ * Mirrors the server-side source of truth:
+ * apps/server-ts/src/engine/global-settings.ts
+ */
+export const GLOBAL_SETTINGS_MAP: Record<string, Record<string, string>> = {
+  "openai-llm": { apiKey: "openai.apiKey", model: "openai.model" },
+  "anthropic-llm": { apiKey: "anthropic.apiKey", model: "anthropic.model" },
+  "google-llm": { apiKey: "google.apiKey", model: "google.model" },
+  "ollama-llm": { host: "ollama.host", model: "ollama.model" },
+  "mistral-llm": { apiKey: "mistral.apiKey", model: "mistral.model" },
+  "groq-llm": { apiKey: "groq.apiKey", model: "groq.model" },
+  "voicevox-tts": { host: "voicevox.host" },
+  "coeiroink-tts": { host: "coeiroink.host" },
+  "sbv2-tts": { host: "sbv2.host" },
+  "aivis-tts": { host: "aivis.host" },
+  "openai-tts": { apiKey: "openai.apiKey" },
+};


### PR DESCRIPTION
## 概要

APIキー等のフィールドがノード側で空のとき、エンジンはグローバル設定の値で補完するが、インライン編集UIではそれが見えなかった（旧右パネルにあった表示が Phase 2 で引き継がれていなかった）。closes #233

- `GLOBAL_SETTINGS_MAP` を `lib/globalSettingsMap.ts` へ共通化（NodeSettings と共用、サーバー側 `engine/global-settings.ts` のミラー）
- ノード側が未設定 かつ グローバル設定に値があるフィールドのヘッダー行に「グローバル」バッジを表示（ホバーで「ノード側が未設定のため、グローバル設定の値を使用しています（入力すると上書き）」）
- 要約値の補正: グローバル値が使われる場合はその値を要約に表示（従来はプラグインのデフォルト値が表示され、実際に使われる値と食い違っていた）
- **password型フィールドは値を表示せずバッジのみ**（秘密情報を出さない）

## テスト計画

- [x] ローカルで `npm run build` 成功（型チェック込み）
- [x] ブラウザ検証: グローバルに openai.apiKey が設定済みの環境で、openai-llm ノードの API Key 行に「グローバル」バッジが表示され、値は表示されないことを確認
- [x] ブラウザ検証: ノード側に値がある Model 行にはバッジが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)