### PR TITLE
feat: ログ表示を刷新 — 実行サイクル単位のアクティビティドロワー

### DIFF
--- a/apps/server-ts/src/engine/executor.ts
+++ b/apps/server-ts/src/engine/executor.ts
@@ -730,6 +730,12 @@ export class WorkflowExecutor {
         const event: Event = (eventData as any).event;
         const sourceNodeId: string = (eventData as any).source_node_id;
 
+        // One dequeued event = one execution cycle. The id groups all node
+        // statuses of this wave so the frontend can render it as one entry.
+        const cycleId = crypto.randomUUID();
+        const cycleTrigger = this.buildCycleTrigger(sourceNodeId, event);
+        let cycleFirstStatus = true;
+
         await this.log(workflowId, sourceNodeId, `Processing event: ${event.type}`, "info");
 
         const downstreamIds = this.getDownstreamNodes(sourceNodeId, adjacency);
@@ -774,7 +780,13 @@ export class WorkflowExecutor {
             continue;
           }
 
-          await this.updateNodeStatus(workflowId, node.id, "running");
+          await this.updateNodeStatus(
+            workflowId,
+            node.id,
+            "running",
+            cycleFirstStatus ? { cycleId, cycleTrigger } : { cycleId },
+          );
+          cycleFirstStatus = false;
 
           try {
             const startTime = Date.now();
@@ -786,9 +798,14 @@ export class WorkflowExecutor {
               outputs,
               duration,
               resultSummary,
+              cycleId,
+              textPreview: this.buildTextPreview(outputs),
             });
           } catch (err) {
-            await this.updateNodeStatus(workflowId, node.id, "error", { error: String(err) });
+            await this.updateNodeStatus(workflowId, node.id, "error", {
+              error: String(err),
+              cycleId,
+            });
             await this.log(workflowId, node.id, `Node error: ${err}`, "error");
           }
         }
@@ -857,6 +874,15 @@ export class WorkflowExecutor {
 
     const nodeOutputs = new Map<string, Record<string, any>>();
 
+    // A linear run is a single execution cycle
+    const cycleId = crypto.randomUUID();
+    const cycleTrigger = {
+      sourceNodeId: executionOrder[0]?.id ?? "",
+      eventType: "manual",
+      summary: "手動実行",
+    };
+    let cycleFirstStatus = true;
+
     for (const node of executionOrder) {
       if (!this.runningWorkflows.has(workflowId)) break;
 
@@ -868,7 +894,13 @@ export class WorkflowExecutor {
       }
 
       await this.log(workflowId, node.id, `Executing node: ${node.type}`, "info");
-      await this.updateNodeStatus(workflowId, node.id, "running");
+      await this.updateNodeStatus(
+        workflowId,
+        node.id,
+        "running",
+        cycleFirstStatus ? { cycleId, cycleTrigger } : { cycleId },
+      );
+      cycleFirstStatus = false;
 
       try {
         const startTime = Date.now();
@@ -880,11 +912,14 @@ export class WorkflowExecutor {
           outputs,
           duration,
           resultSummary,
+          cycleId,
+          textPreview: this.buildTextPreview(outputs),
         });
         await this.log(workflowId, node.id, `Node completed: ${node.type}`, "info");
       } catch (err) {
         await this.updateNodeStatus(workflowId, node.id, "error", {
           error: String(err),
+          cycleId,
         });
         await this.log(workflowId, node.id, `Node error: ${err}`, "error");
         throw err;
@@ -1224,6 +1259,28 @@ export class WorkflowExecutor {
   }
 
   // ─── Result Summary ────────────────
+
+  /** Trigger info attached to the first node status of an execution cycle. */
+  private buildCycleTrigger(sourceNodeId: string, event: Event): Record<string, any> {
+    const payload = event.payload ?? {};
+    const text =
+      typeof payload.text === "string"
+        ? payload.text
+        : typeof payload.message === "string"
+          ? payload.message
+          : "";
+    return {
+      sourceNodeId,
+      eventType: event.type,
+      summary: text ? text.slice(0, 60) : event.type,
+    };
+  }
+
+  /** First characters of a text-like output, for the activity feed summary line. */
+  private buildTextPreview(outputs: Record<string, any> | undefined): string | undefined {
+    const t = outputs?.response ?? outputs?.text;
+    return typeof t === "string" && t.trim() ? t.slice(0, 80) : undefined;
+  }
 
   private buildResultSummary(outputs: Record<string, any> | undefined): string {
     if (!outputs || Object.keys(outputs).length === 0) return "No output";

--- a/apps/web/app/(editor)/editor/[id]/client-page.tsx
+++ b/apps/web/app/(editor)/editor/[id]/client-page.tsx
@@ -6,6 +6,7 @@ import { ReactFlowProvider, useReactFlow } from '@xyflow/react';
 import Canvas from '@/components/editor/Canvas';
 import Sidebar from '@/components/editor/Sidebar';
 import NodeSettings from '@/components/panels/NodeSettings';
+import ActivityDrawer from '@/components/panels/ActivityDrawer';
 import ExpressionPresets from '@/components/panels/ExpressionPresets';
 import MotionLibrary, { Motion } from '@/components/panels/MotionLibrary';
 import { AvatarView, RendererType } from '@/components/avatar';
@@ -950,6 +951,9 @@ export default function EditorPage() {
         >
           <ZoomControls />
         </div>
+
+        {/* Activity drawer (execution cycles + raw log) */}
+        <ActivityDrawer />
 
         {/* Node settings panel — opened on demand from a node's gear button or
             from complex/dynamic field rows that cannot be edited inline */}

--- a/apps/web/components/panels/ActivityDrawer.tsx
+++ b/apps/web/components/panels/ActivityDrawer.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { useWorkflowStore } from '@/stores/workflowStore';
+import { usePluginStore } from '@/stores/pluginStore';
+import { toast } from '@/stores/toastStore';
+import type { ActivityCycle, CycleStep } from '@/lib/types';
+
+// Status colors follow the node border color language:
+// green = completed, red = error, blue = running
+const STATUS_COLOR: Record<ActivityCycle['status'], string> = {
+  completed: '#10B981',
+  error: '#EF4444',
+  running: '#3B82F6',
+};
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString('ja-JP', { hour12: false });
+}
+
+function formatDuration(ms: number | undefined): string {
+  if (!ms) return '';
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// Trigger display convention (icon-less): quoted text = utterance-like input,
+// plain labels = system triggers
+function triggerLabel(cycle: ActivityCycle): string {
+  const t = cycle.trigger;
+  if (!t) return '実行';
+  if (t.eventType === 'manual') return '手動実行';
+  if (t.summary && t.summary !== t.eventType) return `「${t.summary}」`;
+  return t.eventType;
+}
+
+export default function ActivityDrawer() {
+  const { cycles, logs, nodes, selectNode, clearCycles, clearLogs, isExecuting } = useWorkflowStore();
+  const { getPluginLabel } = usePluginStore();
+
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<'activity' | 'raw'>('activity');
+  const [expandedCycles, setExpandedCycles] = useState<Record<string, boolean>>({});
+
+  const errorCount = useMemo(() => cycles.filter((c) => c.status === 'error').length, [cycles]);
+
+  const nodeLabel = (nodeId: string): string => {
+    const node = nodes.find((n) => n.id === nodeId);
+    return node ? getPluginLabel(node.type) : nodeId;
+  };
+
+  // Newest first so the latest cycle is visible without scrolling
+  const ordered = useMemo(() => [...cycles].reverse(), [cycles]);
+
+  const responsePreview = (cycle: ActivityCycle): string => {
+    if (cycle.status === 'error') {
+      const failed = cycle.steps.find((s) => s.status === 'error');
+      if (failed) return `${nodeLabel(failed.nodeId)}: ${failed.error ?? 'エラー'}`;
+    }
+    for (let i = cycle.steps.length - 1; i >= 0; i--) {
+      const p = cycle.steps[i].textPreview;
+      if (p) return `「${p}」`;
+    }
+    return '';
+  };
+
+  const copyError = async (step: CycleStep) => {
+    try {
+      await navigator.clipboard.writeText(`${nodeLabel(step.nodeId)}: ${step.error ?? ''}`);
+      toast.success('エラー内容をコピーしました');
+    } catch {
+      toast.error('コピーに失敗しました');
+    }
+  };
+
+  return (
+    <div
+      className="absolute z-20 flex flex-col"
+      style={{ left: '325px', right: '20px', bottom: '20px' }}
+    >
+      {/* Body (above the toggle bar, opens upward) */}
+      {open && (
+        <div
+          className="flex flex-col overflow-hidden"
+          style={{
+            background: 'rgba(17, 24, 39, 0.97)',
+            border: '1px solid rgba(255,255,255,0.1)',
+            borderBottom: 'none',
+            borderRadius: '12px 12px 0 0',
+            height: '38vh',
+            minHeight: '180px',
+          }}
+        >
+          {/* Tabs */}
+          <div className="flex border-b border-white/10 flex-shrink-0">
+            {([['activity', 'アクティビティ'], ['raw', '生ログ']] as const).map(([key, label]) => (
+              <button
+                key={key}
+                onClick={() => setTab(key)}
+                className={`px-4 py-1.5 text-xs transition-colors ${
+                  tab === key
+                    ? 'text-white border-b-2 border-emerald-400 bg-white/5'
+                    : 'text-white/45 hover:text-white/70'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+            <div className="ml-auto flex items-center pr-2">
+              <button
+                onClick={() => (tab === 'activity' ? clearCycles() : clearLogs())}
+                className="text-[10px] text-white/40 hover:text-white/80 px-2 py-1 transition-colors"
+              >
+                クリア
+              </button>
+            </div>
+          </div>
+
+          {/* Activity tab */}
+          {tab === 'activity' && (
+            <div className="flex-1 overflow-y-auto">
+              {ordered.length === 0 ? (
+                <div className="text-white/35 text-xs text-center py-6">
+                  まだ実行履歴がありません。ワークフローを実行するとここに表示されます
+                </div>
+              ) : (
+                ordered.map((cycle) => {
+                  const isExpanded = !!expandedCycles[cycle.id];
+                  const color = STATUS_COLOR[cycle.status];
+                  return (
+                    <div key={cycle.id} className="border-b border-white/5">
+                      {/* Summary row */}
+                      <button
+                        className="w-full text-left flex items-center gap-2 px-2 py-1.5 hover:bg-white/5 transition-colors"
+                        style={{ borderLeft: `3px solid ${color}` }}
+                        onClick={() =>
+                          setExpandedCycles((prev) => ({ ...prev, [cycle.id]: !prev[cycle.id] }))
+                        }
+                        aria-expanded={isExpanded}
+                      >
+                        <span className="text-[10px] text-white/35 select-none flex-shrink-0 w-3">
+                          {isExpanded ? '▽' : '▷'}
+                        </span>
+                        <span className="text-[10px] text-white/40 flex-shrink-0 font-mono">
+                          {formatTime(cycle.startedAt)}
+                        </span>
+                        <span
+                          className="text-[11px] truncate flex-shrink-0 max-w-[30%]"
+                          style={{ color: cycle.status === 'error' ? '#FCA5A5' : 'rgba(255,255,255,0.85)' }}
+                        >
+                          {triggerLabel(cycle)}
+                        </span>
+                        <span
+                          className="text-[11px] truncate flex-1"
+                          style={{ color: cycle.status === 'error' ? '#FCA5A5' : 'rgba(255,255,255,0.6)' }}
+                        >
+                          {responsePreview(cycle)}
+                        </span>
+                        <span className="text-[10px] text-white/40 flex-shrink-0 font-mono">
+                          {cycle.status === 'running' ? '実行中' : formatDuration(cycle.totalDuration)}
+                        </span>
+                      </button>
+
+                      {/* Steps (expanded) */}
+                      {isExpanded && (
+                        <div className="pb-1" style={{ borderLeft: `3px solid ${color}` }}>
+                          {cycle.steps.map((step, i) => (
+                            <div
+                              key={`${step.nodeId}-${i}`}
+                              className="flex items-start gap-2 pl-7 pr-3 py-1 hover:bg-white/5 cursor-pointer"
+                              onClick={() => selectNode(step.nodeId)}
+                              title="クリックでノードを選択"
+                            >
+                              <span
+                                className="text-[10px] flex-shrink-0 w-[110px] truncate"
+                                style={{ color: STATUS_COLOR[step.status] }}
+                              >
+                                {nodeLabel(step.nodeId)}
+                              </span>
+                              <span className="text-[10px] text-white/40 flex-shrink-0 w-10 font-mono text-right">
+                                {step.status === 'running' ? '…' : formatDuration(step.duration)}
+                              </span>
+                              {step.status === 'error' ? (
+                                <span className="text-[10px] text-red-300 break-words flex-1">
+                                  {step.error}
+                                  <button
+                                    className="ml-2 text-white/40 hover:text-white/80 underline"
+                                    onClick={(e) => { e.stopPropagation(); void copyError(step); }}
+                                  >
+                                    コピー
+                                  </button>
+                                </span>
+                              ) : (
+                                <span className="text-[10px] text-white/55 truncate flex-1">
+                                  {step.textPreview ? `「${step.textPreview}」` : step.resultSummary ?? ''}
+                                </span>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          )}
+
+          {/* Raw log tab */}
+          {tab === 'raw' && (
+            <div className="flex-1 overflow-y-auto px-3 py-2" style={{ fontFamily: 'monospace', fontSize: '11px' }}>
+              {logs.length === 0 ? (
+                <div className="text-white/35 text-center py-6">ログはまだありません</div>
+              ) : (
+                logs.map((log) => (
+                  <div
+                    key={log.id}
+                    className="mb-0.5 break-words"
+                    style={{
+                      color:
+                        log.level === 'error' ? '#EF4444'
+                        : log.level === 'warning' ? '#F59E0B'
+                        : log.level === 'success' ? '#10B981'
+                        : log.level === 'debug' ? '#6B7280'
+                        : 'rgba(255,255,255,0.6)',
+                    }}
+                  >
+                    <span style={{ opacity: 0.5 }}>[{formatTime(log.timestamp)}]</span> {log.message}
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Toggle bar */}
+      <button
+        className="flex items-center gap-2 px-3 py-1.5 text-xs transition-colors hover:bg-white/5"
+        style={{
+          background: 'rgba(17, 24, 39, 0.95)',
+          border: '1px solid rgba(255,255,255,0.1)',
+          borderRadius: open ? '0 0 12px 12px' : '12px',
+          color: 'rgba(255,255,255,0.7)',
+        }}
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+      >
+        <span className="select-none text-white/40">{open ? '▽' : '△'}</span>
+        <span>アクティビティ</span>
+        {isExecuting && <span className="w-1.5 h-1.5 rounded-full bg-blue-400 animate-pulse" />}
+        {cycles.length > 0 && (
+          <span className="text-white/35">{cycles.length}件</span>
+        )}
+        {errorCount > 0 && (
+          <span className="text-red-400 font-medium">エラー {errorCount}</span>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -197,6 +197,32 @@ export interface NodeStatus {
   data?: any;
 }
 
+// Activity feed: one execution cycle = one trigger firing and its downstream wave
+export interface CycleStep {
+  nodeId: string;
+  status: 'running' | 'completed' | 'error';
+  startedAt: string;
+  duration?: number;
+  resultSummary?: string;
+  textPreview?: string;
+  error?: string;
+}
+
+export interface CycleTrigger {
+  sourceNodeId: string;
+  eventType: string;
+  summary: string;
+}
+
+export interface ActivityCycle {
+  id: string;
+  startedAt: string;
+  trigger?: CycleTrigger;
+  steps: CycleStep[];
+  status: 'running' | 'completed' | 'error';
+  totalDuration: number;
+}
+
 // Avatar types
 export type AvatarRendererType = 'vrm' | 'vtube-studio' | 'png';
 

--- a/apps/web/stores/workflowStore.ts
+++ b/apps/web/stores/workflowStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { v4 as uuidv4 } from 'uuid';
-import { WorkflowNode, Connection, ExecutionLog, NodeStatus, CharacterConfig } from '@/lib/types';
+import { WorkflowNode, Connection, ExecutionLog, NodeStatus, CharacterConfig, ActivityCycle, CycleStep } from '@/lib/types';
 
 // History state for undo/redo
 interface HistoryState {
@@ -31,6 +31,7 @@ interface WorkflowState {
   // Execution state
   logs: ExecutionLog[];
   nodeStatuses: Record<string, NodeStatus>;
+  cycles: ActivityCycle[];
 
   // Derived state (reachable nodes from BFS)
   reachableNodeIds: Set<string>;
@@ -68,6 +69,7 @@ interface WorkflowState {
   setExecuting: (executing: boolean) => void;
   addLog: (log: Omit<ExecutionLog, 'id' | 'timestamp'>) => void;
   clearLogs: () => void;
+  clearCycles: () => void;
   setNodeStatus: (nodeId: string, status: NodeStatus['status'], data?: any) => void;
 
   // Bulk actions
@@ -92,6 +94,72 @@ const defaultCharacter: CharacterConfig = {
   name: 'AI Assistant',
   personality: 'Friendly and helpful virtual streamer',
 };
+
+const MAX_CYCLES = 100;
+
+// Fold a node.status event into the activity cycle list. Statuses without a
+// cycleId (validation highlights, listening, idle resets) are ignored here.
+function aggregateCycle(
+  cycles: ActivityCycle[],
+  nodeId: string,
+  status: NodeStatus['status'],
+  data?: any,
+): ActivityCycle[] {
+  const cycleId: string | undefined = data?.cycleId;
+  if (!cycleId || (status !== 'running' && status !== 'completed' && status !== 'error')) {
+    return cycles;
+  }
+
+  let next = [...cycles];
+  let idx = next.findIndex((c) => c.id === cycleId);
+  if (idx === -1) {
+    next.push({
+      id: cycleId,
+      startedAt: new Date().toISOString(),
+      trigger: data?.cycleTrigger,
+      steps: [],
+      status: 'running',
+      totalDuration: 0,
+    });
+    if (next.length > MAX_CYCLES) next = next.slice(-MAX_CYCLES);
+    idx = next.findIndex((c) => c.id === cycleId);
+  }
+
+  const cycle = { ...next[idx] };
+  if (data?.cycleTrigger && !cycle.trigger) cycle.trigger = data.cycleTrigger;
+
+  const steps = [...cycle.steps];
+  const runningIdx = steps.findIndex((s) => s.nodeId === nodeId && s.status === 'running');
+  if (status === 'running') {
+    steps.push({ nodeId, status: 'running', startedAt: new Date().toISOString() });
+  } else {
+    const finished: CycleStep = {
+      nodeId,
+      status,
+      startedAt: runningIdx !== -1 ? steps[runningIdx].startedAt : new Date().toISOString(),
+      duration: data?.duration,
+      resultSummary: data?.resultSummary,
+      textPreview: data?.textPreview,
+      error: data?.error,
+    };
+    if (runningIdx !== -1) {
+      steps[runningIdx] = finished;
+    } else {
+      steps.push(finished);
+    }
+  }
+
+  cycle.steps = steps;
+  cycle.status = steps.some((s) => s.status === 'error')
+    ? 'error'
+    : steps.some((s) => s.status === 'running')
+      ? 'running'
+      : 'completed';
+  cycle.totalDuration = steps.reduce((sum, s) => sum + (s.duration ?? 0), 0);
+
+  next[idx] = cycle;
+  return next;
+}
 
 // Helper to save current state to history
 const saveToHistory = (state: WorkflowState): Partial<WorkflowState> => ({
@@ -176,6 +244,7 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
   clipboard: null,
   logs: [],
   nodeStatuses: {},
+  cycles: [],
 
   // Basic setters
   setWorkflowId: (id) => set({ workflowId: id }),
@@ -397,12 +466,15 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
 
   clearLogs: () => set({ logs: [] }),
 
+  clearCycles: () => set({ cycles: [] }),
+
   setNodeStatus: (nodeId, status, data) => {
     set((state) => ({
       nodeStatuses: {
         ...state.nodeStatuses,
         [nodeId]: { nodeId, status, data },
       },
+      cycles: aggregateCycle(state.cycles, nodeId, status, data),
     }));
   },
 
@@ -437,6 +509,7 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
       clipboard: null,
       logs: [],
       nodeStatuses: {},
+      cycles: [],
       reachableNodeIds: new Set<string>(),
       hasStartNode: false,
     });


### PR DESCRIPTION
## 概要

#194 のログ表示刷新。コンソール形式の行ログをやめ、**実行サイクル（トリガー発火1回分）単位のアクティビティフィード**として再設計した。デザインは #194 のコメントに記録した確定版（2026-06-10 議論）に準拠。closes #194

### バックエンド
- イベント処理1回（またはリニア実行1回）＝1サイクルとして `cycleId` を発行し、`node.status` イベントに付与
- サイクル先頭のステータスにトリガー情報（発生源ノード・イベント種別・テキスト要約60字）を添付
- テキスト系出力の冒頭80字を `textPreview` として completed ステータスに追加

### フロントエンド
- キャンバス下部に折りたたみ式**アクティビティドロワー**を新設
  - 要約行: `時刻 トリガー内容 →応答冒頭 所要時間`（アイコンレス・ステータスは左端カラーバー＋文字色。緑=成功/赤=失敗/青=実行中）
  - トリガー表記規約: かぎ括弧「…」=発話系入力、`手動実行`等=システム系
  - ▽/▷ でサイクル展開 → 実行順ステップリスト（ノード名・所要時間・結果要約。エラーは全文＋コピーボタン）
  - ステップクリックで該当ノードを選択
  - 「生ログ」タブで従来コンソール形式も参照可（トラブルシュート用）
- `workflowStore` に cycles 集約を追加（直近100サイクル保持）

## テスト計画

- [x] `bun test tests/` 227件全pass（cycleId付与によるリグレッションなし）
- [x] `npm run build` 成功（型チェック込み）
- [x] ブラウザ検証（リニア実行）: 「手動実行 「Hello world!...」 2.0s」の要約行、展開で8ステップの実行順リスト・所要時間・結果要約を確認
- [x] ブラウザ検証: LLM→VOICEVOX→再生のフルチェーン実行で7.3sのサイクルが記録されることを確認
- [x] 生ログタブの表示確認
- [ ] イベント駆動モード（チャット連続発火での複数サイクル）はユーザー検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)