### PR TITLE
fix: index.tsのimport順をBiomeのソート規則に合わせる

### DIFF
--- a/apps/server-ts/src/index.ts
+++ b/apps/server-ts/src/index.ts
@@ -8,12 +8,12 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { initDb } from "./db/database";
 import { WorkflowExecutor } from "./engine/executor";
-import { shutdownGracefully } from "./shutdown";
 import { integrationRoutes } from "./routes/integrations";
 import { pluginRoutes } from "./routes/plugins";
 import { settingsRoutes } from "./routes/settings";
 import { templateRoutes } from "./routes/templates";
 import { setExecutor, setWSBroadcaster, workflowRoutes } from "./routes/workflows";
+import { shutdownGracefully } from "./shutdown";
 import { createWebSocketHandler, setExecutorForWS, wsBroadcaster } from "./websocket/handler";
 
 const app = new Hono();


### PR DESCRIPTION
## 概要

PR #237 がBackend Check失敗（importソート順1件）のままマージされてしまったため、devのCIを修復する。`./shutdown` のimportをBiomeのソート規則に従う位置へ移動。

## テスト計画
- [x] ローカルでbiome checkを実行し「Import statements could be sorted」が解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)