### PR TITLE
fix: twitch-chat接続が確立できないとワークフロー停止がハングする問題を修正

### DIFF
--- a/apps/server-ts/src/engine/executor.ts
+++ b/apps/server-ts/src/engine/executor.ts
@@ -375,7 +375,11 @@ export class WorkflowExecutor {
   }
 
   /** Cap a plugin lifecycle call so a hung plugin cannot block the engine. */
-  private async runWithTimeout(promise: Promise<unknown>, ms: number, label: string): Promise<void> {
+  private async runWithTimeout(
+    promise: Promise<unknown>,
+    ms: number,
+    label: string,
+  ): Promise<void> {
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);

--- a/apps/server-ts/src/engine/executor.ts
+++ b/apps/server-ts/src/engine/executor.ts
@@ -225,6 +225,12 @@ export class WorkflowExecutor {
   private vtsWorkflows = new Set<string>();
   private workflowLocks = new Map<string, Promise<void>>();
 
+  // Plugin lifecycle calls are capped so a hung plugin (e.g. a chat client
+  // stuck in a connect-retry loop, issue #239) cannot block workflow
+  // start/stop. Overridable in tests.
+  private setupTimeoutMs = 10_000;
+  private teardownTimeoutMs = 5_000;
+
   // ─── Callbacks ────────────────────
 
   setLogCallback(workflowId: string, callback: LogCallback): void {
@@ -356,11 +362,28 @@ export class WorkflowExecutor {
       const pluginInstance = instance as Record<string, any> | null;
       if (pluginInstance?.setup) {
         try {
-          await pluginInstance.setup(mergedConfig, context);
+          await this.runWithTimeout(
+            pluginInstance.setup(mergedConfig, context),
+            this.setupTimeoutMs,
+            `setup of ${node.type}`,
+          );
         } catch (err) {
           await this.log(workflowId, node.id, `Node setup error: ${err}`, "error");
         }
       }
+    }
+  }
+
+  /** Cap a plugin lifecycle call so a hung plugin cannot block the engine. */
+  private async runWithTimeout(promise: Promise<unknown>, ms: number, label: string): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    });
+    try {
+      await Promise.race([promise, timeout]);
+    } finally {
+      clearTimeout(timer);
     }
   }
 
@@ -385,17 +408,24 @@ export class WorkflowExecutor {
     if (!runtimes) return;
     this.nodeInstances.delete(workflowId);
 
-    for (const runtime of runtimes.values()) {
-      // biome-ignore lint/suspicious/noExplicitAny: plugin instance shape defined at runtime
-      const inst = runtime.instance as Record<string, any> | null;
-      if (inst?.teardown) {
+    // Concurrent with a per-node cap: one hung teardown must not delay the
+    // others, and total stop time stays bounded regardless of node count.
+    await Promise.allSettled(
+      [...runtimes.values()].map(async (runtime) => {
+        // biome-ignore lint/suspicious/noExplicitAny: plugin instance shape defined at runtime
+        const inst = runtime.instance as Record<string, any> | null;
+        if (!inst?.teardown) return;
         try {
-          await inst.teardown();
+          await this.runWithTimeout(
+            inst.teardown(),
+            this.teardownTimeoutMs,
+            `teardown of ${runtime.nodeType}`,
+          );
         } catch (err) {
           console.error(`Error tearing down node ${runtime.nodeId}:`, err);
         }
-      }
-    }
+      }),
+    );
   }
 
   // ─── Event Filter Check ───────────

--- a/plugins/twitch-chat/node.ts
+++ b/plugins/twitch-chat/node.ts
@@ -47,7 +47,7 @@ export default class TwitchChatNode extends InputNode {
     }
 
     try {
-      await this.connectToTwitch(context);
+      this.connectToTwitch(context);
     } catch (e) {
       await context.log(
         `Failed to connect to Twitch: ${String(e)}`,
@@ -56,7 +56,7 @@ export default class TwitchChatNode extends InputNode {
     }
   }
 
-  private async connectToTwitch(context: NodeContext): Promise<void> {
+  private connectToTwitch(context: NodeContext): void {
     const options: Record<string, any> = {
       channels: [this.channel!],
       connection: {
@@ -99,7 +99,19 @@ export default class TwitchChatNode extends InputNode {
       context.log(`Disconnected from Twitch: ${reason}`, "warning");
     });
 
-    await this.tmiClient.connect();
+    // connect() never settles while tmi.js is in its reconnect-retry loop
+    // (e.g. invalid/expired token), so awaiting it here would block workflow
+    // startup — and the stop that follows (issue #239). Run it as a tracked
+    // background task instead; success/failure surfaces via the handlers above.
+    const client = this.tmiClient;
+    context.createTask(async () => {
+      try {
+        await client.connect();
+      } catch (e) {
+        this.connected = false;
+        await context.log(`Failed to connect to Twitch: ${String(e)}`, "error");
+      }
+    });
   }
 
   private async handleMessage(
@@ -174,13 +186,26 @@ export default class TwitchChatNode extends InputNode {
 
   async teardown(): Promise<void> {
     this.connected = false;
-    if (this.tmiClient) {
-      try {
-        await this.tmiClient.disconnect();
-      } catch {
-        // Ignore disconnect errors
-      }
-      this.tmiClient = null;
+    const client = this.tmiClient;
+    this.tmiClient = null;
+    if (!client) return;
+
+    // Kill the automatic reconnect loop first — a client stuck retrying
+    // never settles disconnect() and would hang workflow shutdown.
+    try {
+      // biome-ignore lint/suspicious/noExplicitAny: opts is internal to tmi.js — best-effort flag flip
+      (client as any).opts.connection.reconnect = false;
+    } catch {
+      // opts shape changed — the disconnect timeout below still bounds us
+    }
+
+    try {
+      await Promise.race([
+        client.disconnect().catch(() => {}),
+        new Promise<void>((resolve) => setTimeout(resolve, 2000)),
+      ]);
+    } catch {
+      // Ignore disconnect errors
     }
   }
 }

--- a/plugins/twitch-chat/node.ts
+++ b/plugins/twitch-chat/node.ts
@@ -199,13 +199,18 @@ export default class TwitchChatNode extends InputNode {
       // opts shape changed — the disconnect timeout below still bounds us
     }
 
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       await Promise.race([
         client.disconnect().catch(() => {}),
-        new Promise<void>((resolve) => setTimeout(resolve, 2000)),
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, 2000);
+        }),
       ]);
     } catch {
       // Ignore disconnect errors
+    } finally {
+      clearTimeout(timer);
     }
   }
 }

--- a/tests/engine/lifecycle-timeout.test.ts
+++ b/tests/engine/lifecycle-timeout.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, mock } from "bun:test";
+import { WorkflowExecutor } from "../../apps/server-ts/src/engine/executor";
+
+// Regression tests for issue #239: a plugin whose setup/teardown never
+// settles (e.g. a chat client stuck in a connect-retry loop) must not hang
+// workflow start/stop.
+
+function never(): Promise<void> {
+  return new Promise(() => {});
+}
+
+function plantRuntime(
+  executor: WorkflowExecutor,
+  workflowId: string,
+  entries: Array<{ nodeId: string; nodeType: string; instance: unknown }>,
+): void {
+  const runtimes = new Map();
+  for (const e of entries) {
+    runtimes.set(e.nodeId, {
+      nodeId: e.nodeId,
+      nodeType: e.nodeType,
+      config: {},
+      instance: e.instance,
+      context: null,
+    });
+  }
+  (executor as any).nodeInstances.set(workflowId, runtimes);
+}
+
+describe("TestLifecycleTimeouts", () => {
+  it("test_runWithTimeout_resolves_for_fast_promise", async () => {
+    const executor = new WorkflowExecutor();
+    await expect(
+      (executor as any).runWithTimeout(Promise.resolve("ok"), 1000, "fast"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("test_runWithTimeout_rejects_for_hung_promise", async () => {
+    const executor = new WorkflowExecutor();
+    await expect(
+      (executor as any).runWithTimeout(never(), 50, "hung op"),
+    ).rejects.toThrow("hung op timed out after 50ms");
+  });
+
+  it("test_hung_teardown_does_not_block_other_nodes_or_stop", async () => {
+    const executor = new WorkflowExecutor();
+    (executor as any).teardownTimeoutMs = 50;
+
+    const okTeardown = mock(async () => {});
+    plantRuntime(executor, "wf1", [
+      { nodeId: "n-hung", nodeType: "hung-plugin", instance: { teardown: never } },
+      { nodeId: "n-ok", nodeType: "ok-plugin", instance: { teardown: okTeardown } },
+    ]);
+
+    const start = Date.now();
+    await (executor as any).teardownNodes("wf1");
+    const elapsed = Date.now() - start;
+
+    expect(okTeardown).toHaveBeenCalledTimes(1);
+    expect(elapsed).toBeLessThan(1000);
+    // Runtimes map is released even when a teardown hung
+    expect((executor as any).nodeInstances.has("wf1")).toBe(false);
+  });
+
+  it("test_teardown_error_does_not_block_others", async () => {
+    const executor = new WorkflowExecutor();
+    (executor as any).teardownTimeoutMs = 50;
+
+    const okTeardown = mock(async () => {});
+    plantRuntime(executor, "wf2", [
+      {
+        nodeId: "n-throw",
+        nodeType: "throwing-plugin",
+        instance: {
+          teardown: async () => {
+            throw new Error("teardown exploded");
+          },
+        },
+      },
+      { nodeId: "n-ok", nodeType: "ok-plugin", instance: { teardown: okTeardown } },
+    ]);
+
+    await expect((executor as any).teardownNodes("wf2")).resolves.toBeUndefined();
+    expect(okTeardown).toHaveBeenCalledTimes(1);
+  });
+
+  it("test_stopWorkflowInternal_completes_with_hung_teardown", async () => {
+    const executor = new WorkflowExecutor();
+    (executor as any).teardownTimeoutMs = 50;
+
+    (executor as any).runningWorkflows.set("wf3", {
+      status: "running",
+      started_at: new Date(),
+      workflow_data: { nodes: [], connections: [] },
+    });
+    plantRuntime(executor, "wf3", [
+      { nodeId: "n-hung", nodeType: "hung-plugin", instance: { teardown: never } },
+    ]);
+
+    const start = Date.now();
+    await executor.stopWorkflow("wf3");
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(2000);
+    expect((executor as any).runningWorkflows.has("wf3")).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

closes #239。Twitch接続が確立できない状態でワークフロー停止がハングする問題を修正。

---

## 何が起きていたか

Twitchチャットノードは起動時に `tmi.js` の `connect()` を **await** していた。tmi.js は `reconnect: true`（デフォルト）のとき、接続に失敗すると **Promiseを解決も拒否もしないまま永久に再試行し続ける**。

その結果:
1. ワークフローの起動チェーン（全ノードの`setup()`を順番に呼ぶ処理）が、twitch-chatの`setup()`で止まったまま返ってこない
2. 停止しようとすると、起動チェーンのロック待ちでstopも永遠に完了しない
3. HTTP応答は10秒でBunのタイムアウトに引っかかり、ステータスは`running`のまま残る

**v2.3.1の実データ（期限切れTwitchトークン）で再現確認済み。** 新旧どちらのデータ形式でも発生する一般バグ。

---

## 修正内容

### 1. twitch-chat プラグイン（根本修正）

**setup: 接続をバックグラウンド化**
- `await this.tmiClient.connect()` → `context.createTask(async () => { await client.connect() })`
- setup()は接続の成否を待たず即座に返る。接続結果はtmi.jsのイベントハンドラ（`connected` / `disconnected`）経由でログに通知
- ワークフローはlistening状態に入り、接続は裏で完了する

**teardown: reconnectループを止めてから切断、2秒で打ち切り**
- `(client as any).opts.connection.reconnect = false` でtmi.jsの自動再接続を停止（try/catchで防御。内部APIが変わっても壊れない）
- `Promise.race([disconnect(), 2秒タイムアウト])` で切断を待つが、2秒で諦める
- `finally` で `clearTimeout` して正常完了時のタイマーリークを防止

### 2. executor（同類バグの再発防止）

**プラグインのsetup/teardownにタイムアウトを導入**
- `setup()` → 10秒上限。超過したらエラーログを出してそのノードのセットアップをスキップ
- `teardown()` → 5秒上限。超過したらエラーログを出して次へ進む
- 実装: `runWithTimeout(promise, ms, label)` — `Promise.race` + `finally` での `clearTimeout`

**teardownを並行実行に変更**
- 旧: `for...of` で1ノードずつ順番にteardown → 1つがハングすると全体がブロック
- 新: `Promise.allSettled([...])` で全ノードを同時にteardown → 1つがハングしても他は即座に完了、合計の停止時間はノード数に依存しない

---

## テスト

### 自動テスト（5件追加、計240件全pass）
- `runWithTimeout` の正常完了 / タイムアウト
- ハングするteardownが他ノードの完了とstop全体を妨げないこと
- throwするteardownが他ノードを妨げないこと
- `stopWorkflow` がハングノード込みで有界時間で完了すること

### 実環境テスト
- v2.3.1実DBのTwitchワークフロー（期限切れトークン）で再現テスト
  - **修正前**: stopが10秒でHTTPタイムアウト → ステータスrunningのまま残留
  - **修正後**: stopが2.0秒・HTTP 200で完了、ステータスidle復帰
  - 再start→即stopの連打も正常

---

## 注意
- Twitchトークンが**有効な**正常系（実際に接続してコメントを受信する）は手元に環境がないため未検証。設計上、接続成功パスはイベントハンドラ経由で従来と同じ動き

🤖 Generated with [Claude Code](https://claude.com/claude-code)