### PR TITLE
chore: Dependabot による依存関係の自動更新を導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+# 依存関係の自動更新設定
+# バージョン更新の PR は dev へ向ける（セキュリティ更新のみ GitHub の仕様で
+# デフォルトブランチ (main) に向くため、マージ後は hotfix と同様に dev へ戻すこと）
+version: 2
+updates:
+  # npm (package-lock.json)
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/apps/web"
+      - "/apps/desktop"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # bun (bun.lock)
+  - package-ecosystem: "bun"
+    directories:
+      - "/apps/server-ts"
+      - "/packages/sdk-ts"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      bun-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # cargo (Tauri)
+  - package-ecosystem: "cargo"
+    directory: "/apps/desktop/src-tauri"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      cargo-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## 概要

- `.github/dependabot.yml` を追加し、依存関係の自動更新を有効化
  - npm: ルート / `apps/web` / `apps/desktop`
  - bun: `apps/server-ts` / `packages/sdk-ts`（`bun.lock` 形式）
  - cargo: `apps/desktop/src-tauri`
  - github-actions: ワークフローで使用するアクション
- 週次（月曜・JST）、minor / patch はグルーピングして PR ノイズを抑制
- バージョン更新 PR は `target-branch: dev` で dev へ向ける

## 補足

- **セキュリティ更新だけは GitHub の仕様によりデフォルトブランチ（main）に向きます**。マージした場合は hotfix と同様、直後に main を dev へマージし戻してください（#246 の検知ワークフローが入れば戻し忘れは自動検出されます）
- 現在デフォルトブランチに **4 件の脆弱性アラート（critical 1 件含む）** が出ています: https://github.com/oboroge0/AITuberFlow/security/dependabot このPRのマージ後、Dependabot が修正 PR を作り始めます
- リポジトリ設定で Dependabot security updates の有効化を推奨（Settings → Advanced Security）

## テスト計画

- [x] YAML 構文を js-yaml で検証
- [ ] マージ後、Insights → Dependency graph → Dependabot で各エコシステムが認識されることを確認

closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
