### PR TITLE
chore: CodeQL によるセキュリティスキャンを導入

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    - cron: '30 2 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
## 概要

- `.github/workflows/codeql.yml` を追加し、CodeQL による静的セキュリティスキャンを導入
- 対象: javascript-typescript（ビルド不要の `build-mode: none`）
- トリガー: dev / main への push・PR、週次スケジュール（月曜 02:30 UTC）

## 補足

- 検出結果はリポジトリの Security → Code scanning に表示されます
- Rust（Tauri 側）への拡張は将来検討（#243 参照）

## テスト計画

- [x] YAML 構文を js-yaml で検証
- [ ] この PR 自体で CodeQL ワークフローが起動し、解析が成功することを確認
- [ ] 既存コードへの警告が出た場合はトリアージ

closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
