### PR TITLE
feat: テストカバレッジの計測と Codecov 連携を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,4 +86,17 @@ jobs:
         run: bun install
 
       - name: Run TypeScript tests
-        run: bun test tests/ --verbose
+        run: bun test tests/ --verbose --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/README.en.md
+++ b/README.en.md
@@ -13,6 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/oboroge0/AITuberFlow/actions/workflows/ci.yml"><img src="https://github.com/oboroge0/AITuberFlow/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/oboroge0/AITuberFlow"><img src="https://codecov.io/gh/oboroge0/AITuberFlow/graph/badge.svg" alt="Coverage"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License: MIT"></a>
   <a href="https://github.com/oboroge0/AITuberFlow"><img src="https://img.shields.io/github/stars/oboroge0/AITuberFlow?style=social" alt="GitHub stars"></a>
   <a href="https://github.com/oboroge0/AITuberFlow/issues"><img src="https://img.shields.io/github/issues/oboroge0/AITuberFlow" alt="GitHub issues"></a>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/oboroge0/AITuberFlow/actions/workflows/ci.yml"><img src="https://github.com/oboroge0/AITuberFlow/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/oboroge0/AITuberFlow"><img src="https://codecov.io/gh/oboroge0/AITuberFlow/graph/badge.svg" alt="Coverage"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License: MIT"></a>
   <a href="https://github.com/oboroge0/AITuberFlow"><img src="https://img.shields.io/github/stars/oboroge0/AITuberFlow?style=social" alt="GitHub stars"></a>
   <a href="https://github.com/oboroge0/AITuberFlow/issues"><img src="https://img.shields.io/github/issues/oboroge0/AITuberFlow" alt="GitHub issues"></a>


### PR DESCRIPTION
## 概要

- CI のテストジョブでカバレッジを計測（`bun test --coverage`、text + lcov レポーター）
- lcov をアーティファクトとしてアップロード
- Codecov へのアップロードステップを追加（`fail_ci_if_error: false` のためトークン未設定でも CI は落ちない）
- README.md / README.en.md に Codecov バッジを追加

## メンテナー側の残作業

- [ ] [Codecov](https://codecov.io) で本リポジトリを有効化し、`CODECOV_TOKEN` をリポジトリシークレットに設定（設定するまでバッジは unknown 表示、アップロードはスキップ相当になります）

## テスト計画

- [x] ローカルで `bun test tests/ --coverage --coverage-reporter=lcov` を実行し、235 テスト全パス＋ `coverage/lcov.info` の生成を確認（bun 1.3.9）
- [x] YAML 構文を js-yaml で検証
- [ ] この PR の CI でアーティファクト `coverage` が生成されることを確認

closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
