### PR TITLE
feat: main→dev マージ戻し忘れの自動検知ワークフローを追加

### DIFF
--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -1,0 +1,31 @@
+name: Branch Sync Check
+
+# 運用上の不変条件「main は常に dev の祖先」を検証する。
+# hotfix を main に入れた後、dev へマージし戻すのを忘れると分岐が始まるため、
+# main への push 時と日次で自動検知する。
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Check main is ancestor of dev
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify main is an ancestor of dev
+        run: |
+          git fetch origin main dev
+          if git merge-base --is-ancestor origin/main origin/dev; then
+            echo "OK: main は dev の祖先です（分岐なし）"
+          else
+            echo "::error::main に dev へ未反映のコミットがあります。hotfix 後の戻し忘れの可能性があります。main を dev へマージし戻してください"
+            exit 1
+          fi


### PR DESCRIPTION
## 概要

- `.github/workflows/branch-sync.yml` を追加
- 「main は常に dev の祖先」という運用上の不変条件（dev→main fast-forward 運用の前提）を、main への push 時・日次 cron・手動実行で検証
- 違反時は「main を dev へマージし戻してください」というエラーで失敗し、hotfix の戻し忘れがその日のうちに発覚する

## テスト計画

- [x] YAML 構文を js-yaml で検証
- [x] ローカルで `git merge-base --is-ancestor origin/main origin/dev` が現状 true であることを確認
- [ ] マージ後、workflow_dispatch で手動実行して成功することを確認

closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)
