### PR TITLE
fix: localhost配信ページにTauri IPCを許可（自動更新/エクスポート/オーバーレイを修正）

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -2,7 +2,10 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main"],
+  "windows": ["main", "overlay-*"],
+  "remote": {
+    "urls": ["http://localhost:*", "http://127.0.0.1:*"]
+  },
   "permissions": [
     "core:default",
     {


### PR DESCRIPTION
## 概要

デスクトップ版で**自動アップデート通知が一度も出ない**問題（および**エクスポート保存**・**オーバーレイ別窓**が動かない問題）の根本修正です。

## 原因

デスクトップ版はフロントを `http://localhost:<port>`（Bunサイドカー配信）に `navigate()` して表示しています。Tauri から見るとこれは**リモートURL**扱いで、デフォルトではそのページに IPC（`window.__TAURI_INTERNALS__` 経由の `invoke`）が許可されません。

そのため **IPC を使う機能だけが揃って無反応**でした（他の機能は全部 HTTP API 経由なので正常）:

- 自動アップデート: `check()` / `downloadAndInstall()` が呼べず、更新があっても通知が出ない（v2.2.0 で updater を入れて以降ずっと）
- ワークフローのエクスポート: ネイティブ保存（`save_workflow_export`）に到達できない
- オーバーレイ: 別ウィンドウ表示（`open_overlay_window`）が動かない

リリース・署名・`latest.json`・updater の配線自体は正しく、**検知の前段（IPC）で止まっていた**のが真因です。

## 修正

`apps/desktop/src-tauri/capabilities/default.json` に Tauri v2 の `remote.urls` を追加し、localhost オリジンに IPC を許可:

```json
"windows": ["main", "overlay-*"],
"remote": {
  "urls": ["http://localhost:*", "http://127.0.0.1:*"]
}
```

- このアプリは**ポートが動的**なので URLPattern のワイルドカードポート(`:*`)で任意ポートを許可
- オーバーレイ窓 `overlay-*` も対象に追加
- セキュリティ: 権限を渡す相手は自前サイドカーが配信する localhost のみ（外部公開なし）。Win/Mac デスクトップ用途で実害なし

## テスト計画

- [x] `tauri dev`（実機ビルド・devtools有効）で再現環境を起動
- [x] 一時診断コマンドで、**動的ポート(`http://localhost:49783`)で配信されたページから Rust へ IPC が到達**することを確認（修正前は ACL 拒否で到達せず）。確認後、診断コードは撤去
- [ ] 配布ビルドで v(古い)→v(新しい) の更新フロー（通知表示→ダウンロード→自動再起動）を最終確認 ※次リリースのデスクトップビルドで

## 関連

- フッターの更新ボタン化（見た目）は別PR #277。本PRはその更新が**そもそも動く**ための土台修正。
- 自動更新を実際にユーザーへ届けるには、本修正を含むバージョンを一度配布する必要がある（旧版には IPC 許可が無いため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
