### PR TITLE
fix: 暗いノード色がダーク背景に同化する問題を修正（Ollama/OBS）

### DIFF
--- a/apps/web/components/editor/CustomNode.tsx
+++ b/apps/web/components/editor/CustomNode.tsx
@@ -54,6 +54,31 @@ const DEFAULT_BG_COLOR = 'rgba(107, 114, 128, 0.1)';
 const DEFAULT_ICON = 'Box';
 const DEFAULT_STATUS = 'Ready';
 
+// Node body is a dark navy (#0F172A). Accent colors darker than this blend into
+// it (e.g. ollama #1F2937), so lift any too-dark accent toward white until it
+// clears a minimum luminance. Keeps the hue, just makes it legible.
+// NOTE: tuned for the current dark theme; revisit when light mode lands.
+const MIN_ACCENT_LUMINANCE = 90; // 0..255
+function legibleAccent(hex: string): string {
+  const m = /^#([0-9a-fA-F]{6})$/.exec(hex.trim());
+  if (!m) return hex;
+  const n = parseInt(m[1], 16);
+  let r = (n >> 16) & 255;
+  let g = (n >> 8) & 255;
+  let b = n & 255;
+  const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  if (lum >= MIN_ACCENT_LUMINANCE) return hex;
+  const f = (MIN_ACCENT_LUMINANCE - lum) / (255 - lum); // mix toward white
+  r = Math.round(r + (255 - r) * f);
+  g = Math.round(g + (255 - g) * f);
+  b = Math.round(b + (255 - b) * f);
+  return `#${((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1)}`;
+}
+
+// Subtle outline so the icon chip always has a crisp edge on the dark body,
+// even for near-neutral accent colors.
+const ICON_CHIP_RING = 'inset 0 0 0 1px rgba(255,255,255,0.14)';
+
 // Chevron SVG components
 const ChevronDown = () => (
   <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -866,7 +891,7 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
   // Get visual config from plugin store (with fallbacks)
   const plugin = getPluginById(data.type);
   const config: NodeVisualConfig = {
-    color: getPluginColor(data.type) || DEFAULT_COLOR,
+    color: legibleAccent(getPluginColor(data.type) || DEFAULT_COLOR),
     bgColor: getPluginBgColor(data.type) || DEFAULT_BG_COLOR,
     icon: renderIcon(getPluginIcon(data.type) || DEFAULT_ICON, { size: 16, color: 'currentColor' }),
     statusText: plugin?.ui?.statusText || DEFAULT_STATUS,
@@ -1530,6 +1555,7 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
               height: '20px',
               borderRadius: '4px',
               background: config.color,
+              boxShadow: ICON_CHIP_RING,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
@@ -1577,6 +1603,7 @@ function CustomNode({ id, data, selected }: CustomNodeProps) {
             height: '28px',
             borderRadius: '6px',
             background: config.color,
+            boxShadow: ICON_CHIP_RING,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',

--- a/plugins/obs-scene-switch/manifest.json
+++ b/plugins/obs-scene-switch/manifest.json
@@ -13,8 +13,8 @@
   "ui": {
     "label": "OBS Scene Switch",
     "icon": "Monitor",
-    "color": "#302E31",
-    "bgColor": "rgba(48, 46, 49, 0.3)",
+    "color": "#8B7CC4",
+    "bgColor": "rgba(139, 124, 196, 0.15)",
     "statusText": "OBS Scene Switch"
   },
   "node": {

--- a/plugins/obs-source-toggle/manifest.json
+++ b/plugins/obs-source-toggle/manifest.json
@@ -13,8 +13,8 @@
   "ui": {
     "label": "OBS Source Toggle",
     "icon": "Eye",
-    "color": "#302E31",
-    "bgColor": "rgba(48, 46, 49, 0.3)",
+    "color": "#8B7CC4",
+    "bgColor": "rgba(139, 124, 196, 0.15)",
     "statusText": "OBS Source Toggle"
   },
   "node": {

--- a/plugins/ollama-llm/manifest.json
+++ b/plugins/ollama-llm/manifest.json
@@ -13,8 +13,8 @@
   "ui": {
     "label": "Ollama",
     "icon": "Cpu",
-    "color": "#1F2937",
-    "bgColor": "rgba(31, 41, 55, 0.3)",
+    "color": "#5E81AC",
+    "bgColor": "rgba(94, 129, 172, 0.15)",
     "statusText": "Model: Ollama"
   },
   "node": {


### PR DESCRIPTION
## 概要

エディタで**暗いアクセント色のノードがダーク背景に同化して見えづらい**問題（特に Ollama）を修正します。

## 原因
- ノード本体は `#0F172A`（ダーク背景と同系）固定で、プラグインの `color` は主にヘッダーのアイコンチップ背景に出る。
- `ollama-llm`(`#1F2937`) や OBS ノード(`#302E31`) は本体とほぼ同色のためチップが埋没していた。

## 修正
- **CustomNode**: アクセント色の輝度が低い場合に表示用へ自動で持ち上げる `legibleAccent` ガードを追加（どんな暗色プラグインも自動で視認可能に）。アイコンチップに細い枠も付与。
- `ollama-llm` / `obs-scene-switch` / `obs-source-toggle` の `color`/`bgColor` を視認性の高い色へ（Ollama=スチールブルー `#5E81AC`、OBS=ペリウィンクル `#8B7CC4`）。サイドバー一覧も改善。

## テスト計画
- [x] `tsc --noEmit` 通過
- [x] ESLint 通過（既存の無関係warning1件のみ）
- [x] manifest JSON 妥当性
- [x] before/after をプレビューでレンダリングし視認性向上を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
