### PR TITLE
fix: オーバーレイのWebSocketに自動再接続を実装

### DIFF
--- a/apps/web/app/(overlay)/overlay/[id]/client-page.tsx
+++ b/apps/web/app/(overlay)/overlay/[id]/client-page.tsx
@@ -40,6 +40,7 @@ import { AvatarView, AvatarState, RendererType } from '@/components/avatar';
 import api from '@/lib/api';
 import { resolveWorkflowId } from '@/lib/routeParams';
 import { getApiBaseUrl, getWsBaseUrl } from '@/lib/runtimeEndpoints';
+import { ReconnectingWebSocket } from '@/lib/reconnectingWebSocket';
 
 const WS_URL = getWsBaseUrl();
 const API_BASE = getApiBaseUrl();
@@ -190,208 +191,217 @@ export default function OverlayPage() {
     if (!workflowId || workflowId === '_') return;
 
     const wsUrl = `${WS_URL.replace(/^http/, 'ws')}/ws`;
-    const ws = new WebSocket(wsUrl);
 
-    ws.onopen = () => {
-      console.log('[Overlay] Connected');
-      setConnected(true);
-      ws.send(JSON.stringify({ type: 'join', payload: { workflowId } }));
-    };
+    // OBS Browser Sources run unattended (no one to hit "reload"), so the
+    // overlay must keep retrying forever on disconnect rather than giving
+    // up after a fixed number of attempts.
+    const rws = new ReconnectingWebSocket({
+      url: wsUrl,
+      maxReconnectAttempts: Infinity,
+      onStatusChange: (status) => {
+        setConnected(status === 'connected');
+        if (status === 'connecting') {
+          console.log('[Overlay] Connecting');
+        } else if (status === 'reconnecting') {
+          console.log('[Overlay] Reconnecting');
+        } else if (status === 'disconnected') {
+          console.log('[Overlay] Disconnected');
+        }
+      },
+      onOpen: () => {
+        console.log('[Overlay] Connected');
+        rws.send(JSON.stringify({ type: 'join', payload: { workflowId } }));
+      },
+      onMessage: (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          const { type, ...rest } = data;
 
-    ws.onclose = () => {
-      console.log('[Overlay] Disconnected');
-      setConnected(false);
-    };
+          switch (type) {
+            // Avatar events
+            case 'avatar.expression':
+              setAvatarState((prev) => ({ ...prev, expression: rest.expression }));
+              break;
 
-    ws.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        const { type, ...rest } = data;
+            case 'avatar.mouth':
+              setAvatarState((prev) => ({ ...prev, mouthOpen: rest.value }));
+              break;
 
-        switch (type) {
-          // Avatar events
-          case 'avatar.expression':
-            setAvatarState((prev) => ({ ...prev, expression: rest.expression }));
-            break;
-
-          case 'avatar.mouth':
-            setAvatarState((prev) => ({ ...prev, mouthOpen: rest.value }));
-            break;
-
-          case 'avatar.motion': {
-            const motionUrl = rest.motionUrl || rest.motion;
-            if (motionUrl) {
-              setAvatarState((prev) => ({ ...prev, motion: motionUrl }));
-            }
-            break;
-          }
-
-          case 'avatar.lookAt':
-            setAvatarState((prev) => ({ ...prev, lookAt: rest }));
-            break;
-
-          case 'avatar.update': {
-            if (rest.renderer || rest.modelUrl || rest.idleAnimation || rest.vtubePort || rest.vtubeMouthParam || rest.vtubeExpressionMap) {
-              let expressionMap: Record<string, string> | undefined;
-              if (rest.vtubeExpressionMap) {
-                try {
-                  expressionMap = typeof rest.vtubeExpressionMap === 'string'
-                    ? JSON.parse(rest.vtubeExpressionMap)
-                    : rest.vtubeExpressionMap;
-                } catch {
-                  console.warn('Failed to parse vtubeExpressionMap');
-                }
+            case 'avatar.motion': {
+              const motionUrl = rest.motionUrl || rest.motion;
+              if (motionUrl) {
+                setAvatarState((prev) => ({ ...prev, motion: motionUrl }));
               }
-
-              setAvatarConfig((prev) => ({
-                renderer: rest.renderer || prev.renderer,
-                modelUrl: rest.modelUrl || prev.modelUrl,
-                animationUrl: rest.idleAnimation || prev.animationUrl,
-                vtubePort: rest.vtubePort || prev.vtubePort,
-                vtubeMouthParam: rest.vtubeMouthParam || prev.vtubeMouthParam,
-                vtubeExpressionMap: expressionMap || prev.vtubeExpressionMap,
-              }));
-            }
-            // Whitelist known avatar state fields instead of spreading arbitrary data
-            setAvatarState((prev) => {
-              const updated: Partial<AvatarState> = {};
-              if (rest.expression !== undefined) updated.expression = rest.expression;
-              if (rest.mouthOpen !== undefined) updated.mouthOpen = rest.mouthOpen;
-              if (rest.motion !== undefined) updated.motion = rest.motion;
-              if (rest.lookAt !== undefined) updated.lookAt = rest.lookAt;
-              return { ...prev, ...updated };
-            });
-            break;
-          }
-
-          // Subtitle events
-          case 'subtitle': {
-            if (subtitleTimerRef.current) clearTimeout(subtitleTimerRef.current);
-            if (subtitleFadeTimerRef.current) clearTimeout(subtitleFadeTimerRef.current);
-
-            if (!rest.text) {
-              setSubtitleVisible(false);
-              subtitleFadeTimerRef.current = setTimeout(() => setSubtitle(null), 300);
               break;
             }
 
-            setSubtitle(rest as SubtitleData);
-            setSubtitleVisible(true);
+            case 'avatar.lookAt':
+              setAvatarState((prev) => ({ ...prev, lookAt: rest }));
+              break;
 
-            if (rest.duration && rest.duration > 0) {
-              subtitleTimerRef.current = setTimeout(() => {
+            case 'avatar.update': {
+              if (rest.renderer || rest.modelUrl || rest.idleAnimation || rest.vtubePort || rest.vtubeMouthParam || rest.vtubeExpressionMap) {
+                let expressionMap: Record<string, string> | undefined;
+                if (rest.vtubeExpressionMap) {
+                  try {
+                    expressionMap = typeof rest.vtubeExpressionMap === 'string'
+                      ? JSON.parse(rest.vtubeExpressionMap)
+                      : rest.vtubeExpressionMap;
+                  } catch {
+                    console.warn('Failed to parse vtubeExpressionMap');
+                  }
+                }
+
+                setAvatarConfig((prev) => ({
+                  renderer: rest.renderer || prev.renderer,
+                  modelUrl: rest.modelUrl || prev.modelUrl,
+                  animationUrl: rest.idleAnimation || prev.animationUrl,
+                  vtubePort: rest.vtubePort || prev.vtubePort,
+                  vtubeMouthParam: rest.vtubeMouthParam || prev.vtubeMouthParam,
+                  vtubeExpressionMap: expressionMap || prev.vtubeExpressionMap,
+                }));
+              }
+              // Whitelist known avatar state fields instead of spreading arbitrary data
+              setAvatarState((prev) => {
+                const updated: Partial<AvatarState> = {};
+                if (rest.expression !== undefined) updated.expression = rest.expression;
+                if (rest.mouthOpen !== undefined) updated.mouthOpen = rest.mouthOpen;
+                if (rest.motion !== undefined) updated.motion = rest.motion;
+                if (rest.lookAt !== undefined) updated.lookAt = rest.lookAt;
+                return { ...prev, ...updated };
+              });
+              break;
+            }
+
+            // Subtitle events
+            case 'subtitle': {
+              if (subtitleTimerRef.current) clearTimeout(subtitleTimerRef.current);
+              if (subtitleFadeTimerRef.current) clearTimeout(subtitleFadeTimerRef.current);
+
+              if (!rest.text) {
                 setSubtitleVisible(false);
                 subtitleFadeTimerRef.current = setTimeout(() => setSubtitle(null), 300);
-              }, rest.duration);
-            }
-            break;
-          }
-
-          // Audio events
-          case 'audio': {
-            if (!rest.filename) break;
-            const audioUrl = rest.filename.startsWith('http')
-              ? rest.filename
-              : `${API_BASE}/api/integrations/audio/${rest.filename}`;
-
-            if (audioRef.current) {
-              audioRef.current.pause();
-            }
-
-            const audio = new Audio(audioUrl);
-            audio.volume = volume;
-            audioRef.current = audio;
-
-            audio.onended = () => {
-              setAvatarState((prev) => ({ ...prev, mouthOpen: 0 }));
-            };
-
-            audio.play().catch(console.error);
-            break;
-          }
-
-          case 'audio.play': {
-            if (!rest.filename) break;
-            const playUrl = rest.filename.startsWith('http')
-              ? rest.filename
-              : `${API_BASE}/api/integrations/audio/${rest.filename}`;
-
-            if (audioRef.current) {
-              audioRef.current.pause();
-            }
-
-            const playAudio = new Audio(playUrl);
-            playAudio.volume = rest.volume ?? volume;
-            audioRef.current = playAudio;
-
-            playAudio.onended = () => {
-              setAvatarState((prev) => ({ ...prev, mouthOpen: 0 }));
-            };
-
-            playAudio.play().catch(console.error);
-            break;
-          }
-
-          case 'audio.stop':
-            if (audioRef.current) {
-              audioRef.current.pause();
-              audioRef.current = null;
-            }
-            break;
-
-          // Donation alert events
-          case 'donation.alert': {
-            const alertData = rest as DonationAlertData;
-            setDonationAlert(alertData);
-            setDonationAlertVisible(true);
-
-            if (alertData.sound) {
-              const soundUrl = alertData.sound.startsWith('http')
-                ? alertData.sound
-                : `${API_BASE}${alertData.sound}`;
-
-              if (donationAudioRef.current) {
-                donationAudioRef.current.pause();
+                break;
               }
 
-              const alertAudio = new Audio(soundUrl);
-              alertAudio.volume = volume;
-              donationAudioRef.current = alertAudio;
-              alertAudio.play().catch(console.error);
+              setSubtitle(rest as SubtitleData);
+              setSubtitleVisible(true);
+
+              if (rest.duration && rest.duration > 0) {
+                subtitleTimerRef.current = setTimeout(() => {
+                  setSubtitleVisible(false);
+                  subtitleFadeTimerRef.current = setTimeout(() => setSubtitle(null), 300);
+                }, rest.duration);
+              }
+              break;
             }
 
-            const duration = alertData.duration || 5000;
-            if (donationTimerRef.current) clearTimeout(donationTimerRef.current);
-            if (donationFadeTimerRef.current) clearTimeout(donationFadeTimerRef.current);
-            donationTimerRef.current = setTimeout(() => {
-              setDonationAlertVisible(false);
-              donationFadeTimerRef.current = setTimeout(() => setDonationAlert(null), 500);
-            }, duration);
-            break;
+            // Audio events
+            case 'audio': {
+              if (!rest.filename) break;
+              const audioUrl = rest.filename.startsWith('http')
+                ? rest.filename
+                : `${API_BASE}/api/integrations/audio/${rest.filename}`;
+
+              if (audioRef.current) {
+                audioRef.current.pause();
+              }
+
+              const audio = new Audio(audioUrl);
+              audio.volume = volume;
+              audioRef.current = audio;
+
+              audio.onended = () => {
+                setAvatarState((prev) => ({ ...prev, mouthOpen: 0 }));
+              };
+
+              audio.play().catch(console.error);
+              break;
+            }
+
+            case 'audio.play': {
+              if (!rest.filename) break;
+              const playUrl = rest.filename.startsWith('http')
+                ? rest.filename
+                : `${API_BASE}/api/integrations/audio/${rest.filename}`;
+
+              if (audioRef.current) {
+                audioRef.current.pause();
+              }
+
+              const playAudio = new Audio(playUrl);
+              playAudio.volume = rest.volume ?? volume;
+              audioRef.current = playAudio;
+
+              playAudio.onended = () => {
+                setAvatarState((prev) => ({ ...prev, mouthOpen: 0 }));
+              };
+
+              playAudio.play().catch(console.error);
+              break;
+            }
+
+            case 'audio.stop':
+              if (audioRef.current) {
+                audioRef.current.pause();
+                audioRef.current = null;
+              }
+              break;
+
+            // Donation alert events
+            case 'donation.alert': {
+              const alertData = rest as DonationAlertData;
+              setDonationAlert(alertData);
+              setDonationAlertVisible(true);
+
+              if (alertData.sound) {
+                const soundUrl = alertData.sound.startsWith('http')
+                  ? alertData.sound
+                  : `${API_BASE}${alertData.sound}`;
+
+                if (donationAudioRef.current) {
+                  donationAudioRef.current.pause();
+                }
+
+                const alertAudio = new Audio(soundUrl);
+                alertAudio.volume = volume;
+                donationAudioRef.current = alertAudio;
+                alertAudio.play().catch(console.error);
+              }
+
+              const duration = alertData.duration || 5000;
+              if (donationTimerRef.current) clearTimeout(donationTimerRef.current);
+              if (donationFadeTimerRef.current) clearTimeout(donationFadeTimerRef.current);
+              donationTimerRef.current = setTimeout(() => {
+                setDonationAlertVisible(false);
+                donationFadeTimerRef.current = setTimeout(() => setDonationAlert(null), 500);
+              }, duration);
+              break;
+            }
+
+            // Execution events
+            case 'execution.stopped':
+              setAvatarState((prev) => ({ ...prev, mouthOpen: 0 }));
+              setSubtitleVisible(false);
+              if (subtitleTimerRef.current) clearTimeout(subtitleTimerRef.current);
+              subtitleFadeTimerRef.current = setTimeout(() => setSubtitle(null), 300);
+              if (audioRef.current) {
+                audioRef.current.pause();
+                audioRef.current = null;
+              }
+              break;
           }
-
-          // Execution events
-          case 'execution.stopped':
-            setAvatarState((prev) => ({ ...prev, mouthOpen: 0 }));
-            setSubtitleVisible(false);
-            if (subtitleTimerRef.current) clearTimeout(subtitleTimerRef.current);
-            subtitleFadeTimerRef.current = setTimeout(() => setSubtitle(null), 300);
-            if (audioRef.current) {
-              audioRef.current.pause();
-              audioRef.current = null;
-            }
-            break;
+        } catch (err) {
+          console.warn('Failed to parse WebSocket message:', err);
         }
-      } catch (err) {
-        console.warn('Failed to parse WebSocket message:', err);
-      }
-    };
+      },
+    });
+
+    rws.connect();
 
     return () => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'leave', payload: { workflowId } }));
-      }
-      ws.close();
+      rws.send(JSON.stringify({ type: 'leave', payload: { workflowId } }));
+      rws.close();
       if (subtitleTimerRef.current) clearTimeout(subtitleTimerRef.current);
       if (subtitleFadeTimerRef.current) clearTimeout(subtitleFadeTimerRef.current);
       if (donationTimerRef.current) clearTimeout(donationTimerRef.current);

--- a/apps/web/lib/reconnectingWebSocket.ts
+++ b/apps/web/lib/reconnectingWebSocket.ts
@@ -1,0 +1,175 @@
+/**
+ * Reconnecting WebSocket helper (framework-agnostic).
+ *
+ * Wraps the native `WebSocket` with exponential backoff + jitter
+ * reconnection, mirroring the logic in `hooks/useWebSocket.ts` but without
+ * any React dependency so it can be reused from non-hook contexts (e.g. the
+ * unattended OBS overlay page, where nobody is around to hit "reload").
+ *
+ * NOTE: `hooks/useWebSocket.ts` still has its own inline reconnect logic.
+ * It was intentionally left untouched by this change to avoid regression
+ * risk in the editor's WebSocket handling; it can be migrated to use this
+ * helper in a follow-up.
+ */
+
+export type ConnectionStatus = 'connected' | 'disconnected' | 'connecting' | 'reconnecting';
+
+export const DEFAULT_INITIAL_RECONNECT_DELAY = 1000; // 1 second
+export const DEFAULT_MAX_RECONNECT_DELAY = 30000; // 30 seconds
+export const DEFAULT_JITTER_FACTOR = 0.5;
+
+/**
+ * Exponential backoff with jitter, capped at `maxDelay`.
+ * `attempt` is 1-indexed (first retry = attempt 1).
+ */
+export function calculateReconnectDelay(
+  attempt: number,
+  initialDelay: number = DEFAULT_INITIAL_RECONNECT_DELAY,
+  maxDelay: number = DEFAULT_MAX_RECONNECT_DELAY,
+  jitterFactor: number = DEFAULT_JITTER_FACTOR,
+): number {
+  const baseDelay = Math.min(initialDelay * Math.pow(2, attempt - 1), maxDelay);
+  const jitter = baseDelay * jitterFactor * Math.random();
+  return baseDelay + jitter;
+}
+
+export interface ReconnectingWebSocketOptions {
+  /** Full ws:// or wss:// URL to connect to. */
+  url: string;
+  /** Called every time the underlying socket finishes connecting (including reconnects). Use it to resend join/auth messages. */
+  onOpen?: () => void;
+  /** Called for every incoming message. */
+  onMessage?: (event: MessageEvent) => void;
+  /** Called whenever the connection status changes. */
+  onStatusChange?: (status: ConnectionStatus, attempt: number) => void;
+  /** Called on socket errors (informational only; reconnection is driven by `onclose`). */
+  onError?: (error: Event) => void;
+  /** Maximum number of reconnect attempts. Defaults to unlimited (`Infinity`). */
+  maxReconnectAttempts?: number;
+  initialReconnectDelay?: number;
+  maxReconnectDelay?: number;
+  jitterFactor?: number;
+}
+
+/**
+ * A WebSocket wrapper that automatically reconnects with exponential
+ * backoff + jitter until `close()` is called explicitly.
+ */
+export class ReconnectingWebSocket {
+  private ws: WebSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private intentionalClose = false;
+
+  private readonly url: string;
+  private readonly onOpenCallback?: () => void;
+  private readonly onMessageCallback?: (event: MessageEvent) => void;
+  private readonly onStatusChangeCallback?: (status: ConnectionStatus, attempt: number) => void;
+  private readonly onErrorCallback?: (error: Event) => void;
+  private readonly maxReconnectAttempts: number;
+  private readonly initialReconnectDelay: number;
+  private readonly maxReconnectDelay: number;
+  private readonly jitterFactor: number;
+
+  constructor(options: ReconnectingWebSocketOptions) {
+    this.url = options.url;
+    this.onOpenCallback = options.onOpen;
+    this.onMessageCallback = options.onMessage;
+    this.onStatusChangeCallback = options.onStatusChange;
+    this.onErrorCallback = options.onError;
+    this.maxReconnectAttempts = options.maxReconnectAttempts ?? Infinity;
+    this.initialReconnectDelay = options.initialReconnectDelay ?? DEFAULT_INITIAL_RECONNECT_DELAY;
+    this.maxReconnectDelay = options.maxReconnectDelay ?? DEFAULT_MAX_RECONNECT_DELAY;
+    this.jitterFactor = options.jitterFactor ?? DEFAULT_JITTER_FACTOR;
+  }
+
+  /** Opens the initial connection. Safe to call only once per instance. */
+  connect(): void {
+    this.intentionalClose = false;
+    this.openSocket();
+  }
+
+  private openSocket(): void {
+    this.onStatusChangeCallback?.(
+      this.reconnectAttempt > 0 ? 'reconnecting' : 'connecting',
+      this.reconnectAttempt,
+    );
+
+    const ws = new WebSocket(this.url);
+    this.ws = ws;
+
+    ws.onopen = () => {
+      this.reconnectAttempt = 0;
+      this.onStatusChangeCallback?.('connected', 0);
+      this.onOpenCallback?.();
+    };
+
+    ws.onclose = () => {
+      this.onStatusChangeCallback?.('disconnected', this.reconnectAttempt);
+      if (!this.intentionalClose) {
+        this.scheduleReconnect();
+      }
+    };
+
+    ws.onerror = (error) => {
+      this.onErrorCallback?.(error);
+    };
+
+    ws.onmessage = (event) => {
+      this.onMessageCallback?.(event);
+    };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.intentionalClose) return;
+
+    const attempt = this.reconnectAttempt + 1;
+    if (attempt > this.maxReconnectAttempts) {
+      this.onStatusChangeCallback?.('disconnected', attempt - 1);
+      return;
+    }
+
+    this.reconnectAttempt = attempt;
+
+    const delay = calculateReconnectDelay(
+      attempt,
+      this.initialReconnectDelay,
+      this.maxReconnectDelay,
+      this.jitterFactor,
+    );
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.openSocket();
+    }, delay);
+  }
+
+  /** Sends a payload if the socket is currently open. Returns whether it was sent. */
+  send(data: string): boolean {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(data);
+      return true;
+    }
+    return false;
+  }
+
+  /** Current underlying socket ready state, or null if never connected. */
+  get readyState(): number | null {
+    return this.ws?.readyState ?? null;
+  }
+
+  /** Closes the connection and stops all future reconnect attempts. */
+  close(): void {
+    this.intentionalClose = true;
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+}


### PR DESCRIPTION
## 概要

- OBS Browser Source に載るオーバーレイ (`apps/web/app/(overlay)/overlay/[id]/client-page.tsx`) のWebSocketは、`ws.onclose` で `setConnected(false)` するだけで再接続処理が一切なかった。サーバー再起動や瞬断が起きると配信画面が永久に静止し、無人画面のため配信者は気づけない問題があった。
- 指数バックオフ＋ジッタで再接続する React 非依存のヘルパー `apps/web/lib/reconnectingWebSocket.ts` を新設した。バックオフ定数・ジッタ計算は既存の `apps/web/hooks/useWebSocket.ts` (エディタ用フック) を踏襲している (`INITIAL_RECONNECT_DELAY=1000ms`, `MAX_RECONNECT_DELAY=30000ms`, `JITTER_FACTOR=0.5`)。
- オーバーレイでは OBS 上でユーザーがリロードできないため、`maxReconnectAttempts: Infinity` を指定し無制限にリトライし続ける（遅延は30秒でキャップ）。接続確立ごとに `onOpen` で `join` メッセージを再送し、`onStatusChange` で `setConnected(true/false)` を更新する。既存の `onmessage` のswitchロジックはそのまま移植し、挙動は変更していない。
- `hooks/useWebSocket.ts` (エディタ用フック) は回帰リスクを避けるため今回は変更していない。将来的にこのヘルパーへ統合可能な設計にしてある。

## 設計からの逸脱

- ヘルパー単体の自動テストは追加していない。`apps/web` にはユニットテストランナー（vitest/jest等）が導入されておらず、リポジトリのテストは root の `bun test tests/`（server-ts の engine/routes 用）のみのため、新規にテストランナーを導入するのはスコープ外と判断した。代わりに手動確認手順をテスト計画に記載する。

## テスト計画

- [x] `apps/web` で `npx tsc --noEmit` → エラーなし
- [x] `npm run lint`（apps/web, root両方）→ 0エラー（既存の警告12件のみ、変更ファイルには影響なし）
- [x] worktree ルートで `npm test`（`bun test tests/`）→ 240 pass / 0 fail
- [ ] 手動確認: `npm run dev` でバックエンド・フロントエンドを起動し `/overlay/{workflowId}` を開く → バックエンド (`apps/server-ts`) を再起動し、オーバーレイが自動的に再接続してjoinし直すこと、`debug=true` パラメータでStatusがConnectedに復帰することを確認する