### PR TITLE
fix: LLMノード失敗時にエラー文字列を配信でそのまま読み上げてしまう事故を修正

### DIFF
--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -53,5 +53,5 @@ export {
 } from "./errors";
 
 // LLM error utilities
-export { handleLLMError, classifyLLMError } from "./llm-utils";
-export type { LLMErrorCategory, LLMErrorResult } from "./llm-utils";
+export { handleLLMError, classifyLLMError, LLMError } from "./llm-utils";
+export type { LLMErrorCategory } from "./llm-utils";

--- a/packages/sdk-ts/src/llm-utils.ts
+++ b/packages/sdk-ts/src/llm-utils.ts
@@ -14,9 +14,21 @@ export type LLMErrorCategory =
   | "api_error"
   | "unknown";
 
-export interface LLMErrorResult {
-  response: string;
-  category: LLMErrorCategory;
+/**
+ * Error thrown by {@link handleLLMError} once an LLM call has failed.
+ *
+ * `message` is a user-facing, classified message (localized where possible)
+ * followed by a short summary of the original error. `category` retains the
+ * classification so callers (e.g. retry logic) can branch on it.
+ */
+export class LLMError extends Error {
+  readonly category: LLMErrorCategory;
+
+  constructor(message: string, category: LLMErrorCategory, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "LLMError";
+    this.category = category;
+  }
 }
 
 /**
@@ -73,49 +85,63 @@ export function classifyLLMError(error: unknown): LLMErrorCategory {
 }
 
 /**
- * Handle an LLM error: classify, log a localized message, and return a structured response.
+ * Handle an LLM error: classify, log a localized message, and throw.
+ *
+ * This never returns a value — LLM failures must not be mistaken for
+ * successful responses by downstream nodes (e.g. a TTS node reading an
+ * error string aloud on stream). Callers should `return await
+ * handleLLMError(...)` from their `catch` block; the executor is
+ * responsible for catching the thrown {@link LLMError}, logging it, and
+ * marking the node as errored so execution does not continue downstream.
  */
 export async function handleLLMError(
   error: unknown,
   provider: string,
   context: { log: (message: string, level?: string) => Promise<void> },
-): Promise<LLMErrorResult> {
+): Promise<never> {
   const category = classifyLLMError(error);
   const message = error instanceof Error ? error.message : String(error);
 
+  let errorMsg: string;
+  let llmErrorMessage: string;
+
   switch (category) {
     case "connection": {
-      const errorMsg = getErrorMessage(ErrorCode.LLM_CONNECTION_FAILED, "ja", {
+      errorMsg = getErrorMessage(ErrorCode.LLM_CONNECTION_FAILED, "ja", {
         provider,
       });
-      await context.log(errorMsg, "error");
-      return { response: "Error: Connection failed", category };
+      llmErrorMessage = `${errorMsg} (${message})`;
+      break;
     }
     case "rate_limit": {
-      const errorMsg = getErrorMessage(ErrorCode.LLM_RATE_LIMIT, "ja", {
+      errorMsg = getErrorMessage(ErrorCode.LLM_RATE_LIMIT, "ja", {
         provider,
       });
-      await context.log(errorMsg, "error");
-      return { response: "Error: Rate limit exceeded", category };
+      llmErrorMessage = `${errorMsg} (${message})`;
+      break;
     }
     case "auth": {
-      const errorMsg = getErrorMessage(ErrorCode.LLM_API_KEY_MISSING, "ja", {
+      errorMsg = getErrorMessage(ErrorCode.LLM_API_KEY_MISSING, "ja", {
         provider,
       });
-      await context.log(errorMsg, "error");
-      return { response: "Error: Authentication failed", category };
+      llmErrorMessage = `${errorMsg} (${message})`;
+      break;
     }
     case "api_error": {
-      const errorMsg = getErrorMessage(ErrorCode.LLM_API_ERROR, "ja", {
+      errorMsg = getErrorMessage(ErrorCode.LLM_API_ERROR, "ja", {
         provider,
         error: message,
       });
-      await context.log(errorMsg, "error");
-      return { response: `Error: ${message}`, category };
+      llmErrorMessage = errorMsg;
+      break;
     }
     default: {
-      await context.log(`Unexpected error: ${message}`, "error");
-      return { response: `Error: ${message}`, category };
+      errorMsg = `Unexpected error: ${message}`;
+      llmErrorMessage = errorMsg;
+      break;
     }
   }
+
+  await context.log(errorMsg, "error");
+  throw new LLMError(llmErrorMessage, category, { cause: error });
 }

--- a/plugins/anthropic-llm/node.ts
+++ b/plugins/anthropic-llm/node.ts
@@ -83,8 +83,7 @@ export default class AnthropicLLMNode extends BaseNode {
 
       return { response };
     } catch (error: unknown) {
-      const result = await handleLLMError(error, "Anthropic", context);
-      return { response: result.response };
+      return await handleLLMError(error, "Anthropic", context);
     }
   }
 

--- a/plugins/google-llm/node.ts
+++ b/plugins/google-llm/node.ts
@@ -83,8 +83,7 @@ export default class GoogleLLMNode extends BaseNode {
 
       return { response: result };
     } catch (error: unknown) {
-      const result = await handleLLMError(error, "Google", context);
-      return { response: result.response };
+      return await handleLLMError(error, "Google", context);
     }
   }
 

--- a/plugins/groq-llm/node.ts
+++ b/plugins/groq-llm/node.ts
@@ -127,8 +127,7 @@ export default class GroqLLMNode extends BaseNode {
 
       return { response: result };
     } catch (error: unknown) {
-      const result = await handleLLMError(error, "Groq", context);
-      return { response: result.response };
+      return await handleLLMError(error, "Groq", context);
     }
   }
 

--- a/plugins/mistral-llm/node.ts
+++ b/plugins/mistral-llm/node.ts
@@ -126,8 +126,7 @@ export default class MistralLLMNode extends BaseNode {
 
       return { response: result };
     } catch (error: unknown) {
-      const result = await handleLLMError(error, "Mistral", context);
-      return { response: result.response };
+      return await handleLLMError(error, "Mistral", context);
     }
   }
 

--- a/plugins/ollama-llm/node.ts
+++ b/plugins/ollama-llm/node.ts
@@ -149,8 +149,7 @@ export default class OllamaLLMNode extends BaseNode {
       if (!response.ok) {
         const errorText = await response.text();
         const httpError = new Error(`HTTP ${response.status}: ${errorText}`);
-        const result = await handleLLMError(httpError, "Ollama", context);
-        return { response: result.response };
+        return await handleLLMError(httpError, "Ollama", context);
       }
 
       const data = (await response.json()) as OllamaGenerateResponse;
@@ -167,8 +166,7 @@ export default class OllamaLLMNode extends BaseNode {
 
       return { response: result };
     } catch (error: unknown) {
-      const result = await handleLLMError(error, "Ollama", context);
-      return { response: result.response };
+      return await handleLLMError(error, "Ollama", context);
     }
   }
 

--- a/plugins/openai-llm/node.ts
+++ b/plugins/openai-llm/node.ts
@@ -165,8 +165,7 @@ export default class OpenAILLMNode extends BaseNode {
 
       return { response: result };
     } catch (error: unknown) {
-      const result = await handleLLMError(error, "OpenAI", context);
-      return { response: result.response };
+      return await handleLLMError(error, "OpenAI", context);
     }
   }
 

--- a/tests/engine/executor.test.ts
+++ b/tests/engine/executor.test.ts
@@ -707,3 +707,76 @@ describe("TestNodeContext", () => {
     expect(ctx.getCharacterPersonality()).toBe("");
   });
 });
+
+// ─── TestRunLinearErrorPropagation ─────────────────────────────────
+// Regression test for the "LLM error read aloud on stream" incident: a node
+// that throws (e.g. an LLM plugin failing via handleLLMError) must stop the
+// run and must not let downstream nodes execute with no/garbage input.
+
+describe("TestRunLinearErrorPropagation", () => {
+  let executor: WorkflowExecutor;
+  const workflowId = "wf-error-halt";
+
+  beforeEach(() => {
+    executor = new WorkflowExecutor();
+    (executor as any).runningWorkflows.set(workflowId, { status: "running" });
+  });
+
+  function registerRuntime(nodeId: string, execute: (...args: any[]) => Promise<any>) {
+    const ctx = new NodeContext({
+      workflowId,
+      nodeId,
+      character: { name: "TestBot" },
+    });
+    const runtimes: Map<string, any> = (executor as any).nodeInstances.get(workflowId) ?? new Map();
+    runtimes.set(nodeId, {
+      nodeId,
+      nodeType: "process",
+      config: {},
+      instance: { execute },
+      context: ctx,
+    });
+    (executor as any).nodeInstances.set(workflowId, runtimes);
+  }
+
+  it("stops execution and does not run downstream nodes when a node throws", async () => {
+    const upstreamExecute = mock(async () => {
+      throw new Error("Error: Rate limit exceeded");
+    });
+    const downstreamExecute = mock(async () => ({ text: "should not run" }));
+
+    registerRuntime("llm", upstreamExecute);
+    registerRuntime("tts", downstreamExecute);
+
+    const nodes = [makeNode("llm", "process"), makeNode("tts", "process")];
+    const connections = [makeConnection("c1", "llm", "response", "tts", "text")];
+
+    await expect(
+      (executor as any).runLinear(workflowId, nodes, connections, {}),
+    ).rejects.toThrow("Error: Rate limit exceeded");
+
+    expect(upstreamExecute).toHaveBeenCalledTimes(1);
+    expect(downstreamExecute).not.toHaveBeenCalled();
+  });
+
+  it("marks the failing node as errored via the status callback", async () => {
+    const statusUpdates: Array<{ nodeId: string; status: string }> = [];
+    executor.setStatusCallback(workflowId, async (nodeId, status) => {
+      statusUpdates.push({ nodeId, status });
+    });
+
+    registerRuntime("llm", async () => {
+      throw new Error("boom");
+    });
+
+    const nodes = [makeNode("llm", "process")];
+
+    await expect(
+      (executor as any).runLinear(workflowId, nodes, [], {}),
+    ).rejects.toThrow("boom");
+
+    expect(statusUpdates).toContainEqual({ nodeId: "llm", status: "running" });
+    expect(statusUpdates).toContainEqual({ nodeId: "llm", status: "error" });
+    expect(statusUpdates.find((s) => s.status === "completed")).toBeUndefined();
+  });
+});

--- a/tests/sdk/llm-utils.test.ts
+++ b/tests/sdk/llm-utils.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, mock } from "bun:test";
 import {
   classifyLLMError,
   handleLLMError,
+  LLMError,
 } from "../../packages/sdk-ts/src/llm-utils";
 
 describe("classifyLLMError", () => {
@@ -95,45 +96,48 @@ describe("handleLLMError", () => {
     };
   }
 
-  it("handles connection errors", async () => {
+  it("throws an LLMError for connection errors", async () => {
     const ctx = createMockContext();
-    const result = await handleLLMError(
-      new Error("ECONNREFUSED"),
-      "OpenAI",
-      ctx,
-    );
-    expect(result.category).toBe("connection");
-    expect(result.response).toBe("Error: Connection failed");
+    let caught: unknown;
+    try {
+      await handleLLMError(new Error("ECONNREFUSED"), "OpenAI", ctx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(LLMError);
+    expect((caught as LLMError).category).toBe("connection");
     expect(ctx.log).toHaveBeenCalledTimes(1);
     expect(ctx.logs[0].level).toBe("error");
     expect(ctx.logs[0].message).toContain("OpenAI");
   });
 
-  it("handles rate limit errors", async () => {
+  it("throws an LLMError for rate limit errors", async () => {
     const ctx = createMockContext();
-    const result = await handleLLMError(
-      new Error("429 Too Many Requests"),
-      "Anthropic",
-      ctx,
-    );
-    expect(result.category).toBe("rate_limit");
-    expect(result.response).toBe("Error: Rate limit exceeded");
+    let caught: unknown;
+    try {
+      await handleLLMError(new Error("429 Too Many Requests"), "Anthropic", ctx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(LLMError);
+    expect((caught as LLMError).category).toBe("rate_limit");
     expect(ctx.logs[0].message).toContain("Anthropic");
   });
 
-  it("handles auth errors", async () => {
+  it("throws an LLMError for auth errors", async () => {
     const ctx = createMockContext();
-    const result = await handleLLMError(
-      new Error("401 Unauthorized"),
-      "Google",
-      ctx,
-    );
-    expect(result.category).toBe("auth");
-    expect(result.response).toBe("Error: Authentication failed");
+    let caught: unknown;
+    try {
+      await handleLLMError(new Error("401 Unauthorized"), "Google", ctx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(LLMError);
+    expect((caught as LLMError).category).toBe("auth");
     expect(ctx.logs[0].message).toContain("Google");
   });
 
-  it("handles generic API errors", async () => {
+  it("throws an LLMError for generic API errors", async () => {
     const ctx = createMockContext();
     class APIError extends Error {
       constructor() {
@@ -141,27 +145,53 @@ describe("handleLLMError", () => {
         this.name = "APIError";
       }
     }
-    const result = await handleLLMError(new APIError(), "Ollama", ctx);
-    expect(result.category).toBe("api_error");
-    expect(result.response).toContain("Model not found");
+    let caught: unknown;
+    try {
+      await handleLLMError(new APIError(), "Ollama", ctx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(LLMError);
+    expect((caught as LLMError).category).toBe("api_error");
+    expect((caught as LLMError).message).toContain("Model not found");
     expect(ctx.logs[0].message).toContain("Ollama");
   });
 
-  it("handles unknown errors", async () => {
+  it("throws an LLMError for unknown errors", async () => {
     const ctx = createMockContext();
-    const result = await handleLLMError(
-      new Error("something unexpected"),
-      "OpenAI",
-      ctx,
-    );
-    expect(result.category).toBe("unknown");
-    expect(result.response).toContain("something unexpected");
+    let caught: unknown;
+    try {
+      await handleLLMError(new Error("something unexpected"), "OpenAI", ctx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(LLMError);
+    expect((caught as LLMError).category).toBe("unknown");
+    expect((caught as LLMError).message).toContain("something unexpected");
     expect(ctx.logs[0].level).toBe("error");
   });
 
-  it("handles non-Error values", async () => {
+  it("throws an LLMError for non-Error values", async () => {
     const ctx = createMockContext();
-    const result = await handleLLMError("string error", "OpenAI", ctx);
-    expect(result.response).toContain("string error");
+    let caught: unknown;
+    try {
+      await handleLLMError("string error", "OpenAI", ctx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(LLMError);
+    expect((caught as LLMError).message).toContain("string error");
+  });
+
+  it("preserves the original error via cause", async () => {
+    const ctx = createMockContext();
+    const original = new Error("ECONNREFUSED");
+    let caught: unknown;
+    try {
+      await handleLLMError(original, "OpenAI", ctx);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as LLMError).cause).toBe(original);
   });
 });


### PR DESCRIPTION
## 概要

- `handleLLMError`（`packages/sdk-ts/src/llm-utils.ts`）が LLM API 失敗時に `{ response: "Error: Rate limit exceeded" }` のようなエラー文字列を**正常な出力として返していた**ため、レート制限や瞬断が起きるとノードは緑（成功）のままになり、標準テンプレートでは `response` → TTS ノードの `text` に直結しているため **VTuber がエラーメッセージをそのまま音声で読み上げてしまう**配信事故があった。
- executor 側は元々ノードが `throw` すれば捕捉してログ出力＋ノードをエラー表示にし、以降のノードを実行しない実装になっていたため、そちらは変更していない。「値を返す」のではなく「throw する」ことが正しい直し方だった。
- `LLMError` クラスを新設して `@aituber-flow/sdk` から export し、`handleLLMError` はエラーを分類・ログ（従来通り日本語メッセージ）した後、値を返す代わりに `LLMError` を `throw` する `Promise<never>` に変更した。
- `handleLLMError` を呼んでいた 6 つの LLM プラグイン（OpenAI / Anthropic / Google / Mistral / Groq / Ollama）の `catch` 節を `return await handleLLMError(...)` に統一し、エラー文字列が `response` として下流ノードへ流れる経路を完全に廃止した。
- 不要になった `LLMErrorResult` 型は削除（他に参照している箇所がないことを grep で確認済み）。`classifyLLMError` の分類ロジックは変更していない。

## 変更ファイル

- `packages/sdk-ts/src/llm-utils.ts` — `LLMError` クラス新設、`handleLLMError` を throw ベースに変更
- `packages/sdk-ts/src/index.ts` — export を更新（`LLMError` を追加、`LLMErrorResult` を削除）
- `plugins/openai-llm/node.ts`
- `plugins/anthropic-llm/node.ts`
- `plugins/google-llm/node.ts`
- `plugins/mistral-llm/node.ts`
- `plugins/groq-llm/node.ts`
- `plugins/ollama-llm/node.ts`（HTTP エラー分岐と catch 節の両方を修正）

## テスト計画

- [x] `tests/sdk/llm-utils.test.ts` を throw 前提のテストに更新（`LLMError` インスタンス・`category`・`cause` を検証）
- [x] `tests/engine/executor.test.ts` に「上流ノードが throw したら下流ノードは実行されない」「失敗ノードが status=error になり completed にはならない」ことを確認する回帰テストを追加
- [x] worktree ルートで `npm test` → 全緑（243 pass / 0 fail）
- [x] `packages/sdk-ts` と `apps/server-ts` の `tsc --noEmit` → エラーなし
- [x] 修正対象の6プラグインを一時 tsconfig で `tsc --noEmit` → エラーなし（プラグインは通常のCI typecheck 対象外のため個別確認）
- [x] `npm run lint` → `apps/server-ts/src/engine/executor.ts` に既存の `noExplicitAny` 警告・CRLF整形差分が残るが、いずれも今回変更していないファイルで dev 上から既存のもの（本PRのスコープ外）

## 設計からの逸脱

- 特になし。指示通り `LLMError` を新設し `handleLLMError` を `Promise<never>` にして throw する形にした。