### PR TITLE
fix: APIキー等の機微情報がAPIレスポンスに平文で露出する問題を修正

### DIFF
--- a/apps/server-ts/src/routes/sensitive-fields.ts
+++ b/apps/server-ts/src/routes/sensitive-fields.ts
@@ -1,0 +1,143 @@
+/**
+ * Shared helpers for detecting, masking, stripping, and restoring
+ * sensitive configuration values (API keys, tokens, passwords, secrets)
+ * across the settings and workflows routes.
+ *
+ * Centralizing this logic keeps GET-masking, export-stripping, and
+ * PUT/start sentinel-restoration all in agreement about what counts as
+ * "sensitive" and how deep to recurse into nested config objects.
+ */
+
+/** Placeholder returned instead of a real secret value in API responses. */
+export const SENTINEL = "********";
+
+/** Guards against pathological/deeply-nested config objects. */
+const MAX_DEPTH = 20;
+
+// Legacy exact-match key names, kept so the historical export-strip
+// behavior stays documented explicitly. SENSITIVE_KEY_PATTERN below is a
+// superset that also catches composite field names such as `llmApiKey`,
+// `botToken`, `oauthToken`, `openai.apiKey`, `apiSecret`, etc.
+const SENSITIVE_KEYS = ["apiKey", "api_key", "password", "secret", "token", "apiSecret"];
+const SENSITIVE_KEYS_LOWER = new Set(SENSITIVE_KEYS.map((k) => k.toLowerCase()));
+
+// `token$` is anchored to the end of the key so that `maxTokens` /
+// `max_tokens` (a token *count*, not a credential) is correctly excluded,
+// while `botToken`, `oauthToken`, `discord.token` etc. are still caught.
+const SENSITIVE_KEY_PATTERN = /api[_-]?key|secret|password|credential|token$/i;
+
+/**
+ * Returns true if a config/settings key name should be treated as
+ * sensitive (API key, token, password, secret, credential) and therefore
+ * masked in GET responses, stripped on export, and eligible for
+ * sentinel-skip/restore on write.
+ *
+ * Known sensitive keys actually used in this codebase (kept here as a
+ * reference for tests): apiKey, api_key, apiSecret, llmApiKey,
+ * botToken, oauthToken, password (obs-* nodes), and global settings keys
+ * like openai.apiKey / anthropic.apiKey / google.apiKey / mistral.apiKey /
+ * groq.apiKey. Explicitly NOT sensitive: model, host, maxTokens,
+ * max_tokens, modelUrl, channelIds, etc.
+ */
+export function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEYS_LOWER.has(key.toLowerCase()) || SENSITIVE_KEY_PATTERN.test(key);
+}
+
+/**
+ * Recursively walk a value, applying `transform` to sensitive string
+ * fields. Non-sensitive fields are recursed into; arrays are mapped;
+ * primitives are returned unchanged. Input is not mutated.
+ */
+function transformSensitiveDeep(
+  value: unknown,
+  transform: (v: unknown) => unknown,
+  depth: number,
+): unknown {
+  if (depth >= MAX_DEPTH) return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => transformSensitiveDeep(item, transform, depth + 1));
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = isSensitiveKey(key)
+        ? transform(inner)
+        : transformSensitiveDeep(inner, transform, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Strip sensitive values down to "" (used for workflow export, which has
+ * always discarded secrets rather than masking them).
+ */
+export function stripSensitiveDeep(value: unknown): unknown {
+  return transformSensitiveDeep(value, (v) => (typeof v === "string" ? "" : v), 0);
+}
+
+/**
+ * Mask sensitive values with SENTINEL for API responses. Empty strings are
+ * left empty (not masked) so clients can distinguish "unset" from "set" —
+ * e.g. the editor's "using global setting" fallback badge relies on being
+ * able to see an empty string for an unset field.
+ */
+export function maskSensitiveDeep(value: unknown): unknown {
+  return transformSensitiveDeep(
+    value,
+    (v) => (typeof v === "string" && v.length > 0 ? SENTINEL : v),
+    0,
+  );
+}
+
+/**
+ * Recursively restore sentinel-masked sensitive fields in `next` with the
+ * corresponding real value from `previous` (matched by identical key
+ * path). If there is no corresponding previous value, the sentinel is left
+ * as-is (saved literally — the user will need to re-enter the key).
+ */
+export function restoreSentinelDeep(next: unknown, previous: unknown, depth = 0): unknown {
+  if (depth >= MAX_DEPTH) return next;
+  if (Array.isArray(next)) {
+    const prevArr = Array.isArray(previous) ? previous : [];
+    return next.map((item, i) => restoreSentinelDeep(item, prevArr[i], depth + 1));
+  }
+  if (next && typeof next === "object") {
+    const prevObj =
+      previous && typeof previous === "object" && !Array.isArray(previous)
+        ? (previous as Record<string, unknown>)
+        : {};
+    const out: Record<string, unknown> = {};
+    for (const [key, inner] of Object.entries(next as Record<string, unknown>)) {
+      if (isSensitiveKey(key) && inner === SENTINEL && key in prevObj) {
+        out[key] = prevObj[key];
+      } else {
+        out[key] = restoreSentinelDeep(inner, prevObj[key], depth + 1);
+      }
+    }
+    return out;
+  }
+  return next;
+}
+
+/**
+ * Restore sentinel-masked sensitive fields across a list of workflow
+ * nodes, matching by node `id` against `previousNodes`. Nodes with no
+ * matching id in `previousNodes` (new nodes, e.g. duplicated in the
+ * editor) are returned unchanged — any sentinel value they carry will be
+ * saved literally.
+ */
+export function restoreSentinelNodes(
+  nextNodes: Record<string, unknown>[],
+  previousNodes: Record<string, unknown>[],
+): Record<string, unknown>[] {
+  const previousById = new Map(
+    previousNodes.filter((n) => typeof n.id === "string").map((n) => [n.id as string, n]),
+  );
+  return nextNodes.map((node) => {
+    const prev = typeof node.id === "string" ? previousById.get(node.id) : undefined;
+    if (!prev) return node;
+    return restoreSentinelDeep(node, prev) as Record<string, unknown>;
+  });
+}

--- a/apps/server-ts/src/routes/settings.ts
+++ b/apps/server-ts/src/routes/settings.ts
@@ -7,6 +7,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { db as defaultDb } from "../db/database";
 import { globalSettings } from "../db/schema";
+import { SENTINEL, isSensitiveKey } from "./sensitive-fields";
 
 const app = new Hono();
 
@@ -16,25 +17,36 @@ export function setDb(newDb: typeof defaultDb): void {
   _db = newDb;
 }
 
-// GET /api/settings — return all settings as Record<string, string>
+// GET /api/settings — return all settings as Record<string, string>.
+// Sensitive values (API keys, tokens, passwords) are masked with SENTINEL
+// so this endpoint never leaks secrets in plaintext. Empty values are left
+// empty so the client can tell "unset" apart from "set".
 app.get("/", async (c) => {
   const rows = _db.select().from(globalSettings).all();
   const result: Record<string, string> = {};
   for (const row of rows) {
-    result[row.key] = row.value;
+    result[row.key] = isSensitiveKey(row.key) && row.value !== "" ? SENTINEL : row.value;
   }
   return c.json(result);
 });
 
-// PUT /api/settings — bulk upsert settings
+// PUT /api/settings — bulk upsert settings.
+// Entries whose value is the SENTINEL placeholder are skipped (the
+// client is echoing back a masked value it never actually edited), so the
+// existing stored secret is preserved. An explicit empty string still
+// overwrites, so users retain a way to clear a key.
 const updateSettingsBody = z.record(z.string(), z.string());
 
 app.put("/", zValidator("json", updateSettingsBody), async (c) => {
   const body = c.req.valid("json");
   const now = new Date().toISOString();
 
+  const entries = Object.entries(body).filter(
+    ([key, value]) => !(isSensitiveKey(key) && value === SENTINEL),
+  );
+
   _db.transaction((tx) => {
-    for (const [key, value] of Object.entries(body)) {
+    for (const [key, value] of entries) {
       tx.insert(globalSettings)
         .values({ key, value, updatedAt: now })
         .onConflictDoUpdate({

--- a/apps/server-ts/src/routes/workflows.ts
+++ b/apps/server-ts/src/routes/workflows.ts
@@ -125,7 +125,9 @@ app.post("/", zValidator("json", createWorkflowBody), async (c) => {
   });
 
   const [row] = await _db.select().from(workflows).where(eq(workflows.id, id));
-  return c.json(workflowToResponse(row));
+  // Echo of client-provided data, but masked anyway so every workflow
+  // response follows the same contract (secrets never appear in responses).
+  return c.json(maskWorkflowResponse(workflowToResponse(row)));
 });
 
 // List workflows
@@ -209,7 +211,11 @@ app.post("/:id/duplicate", async (c) => {
   });
 
   const [row] = await _db.select().from(workflows).where(eq(workflows.id, newId));
-  return c.json(workflowToResponse(row));
+  // The duplicated row keeps the real secrets in the DB (so the copy is
+  // immediately runnable), but the response must be masked like every
+  // other read — otherwise duplicate would be a one-call bypass of the
+  // GET masking.
+  return c.json(maskWorkflowResponse(workflowToResponse(row)));
 });
 
 // Export workflow
@@ -301,7 +307,8 @@ app.post("/import", async (c) => {
   });
 
   const [row] = await _db.select().from(workflows).where(eq(workflows.id, id));
-  return c.json(workflowToResponse(row));
+  // Same response contract as every other workflow endpoint: masked.
+  return c.json(maskWorkflowResponse(workflowToResponse(row)));
 });
 
 // Validate workflow before execution

--- a/apps/server-ts/src/routes/workflows.ts
+++ b/apps/server-ts/src/routes/workflows.ts
@@ -14,6 +14,7 @@ import type { WorkflowExecutor } from "../engine/executor";
 import { validateWorkflow } from "../engine/validator";
 import type { WorkflowResponse } from "../models/workflow";
 import type { WSBroadcaster } from "../websocket/handler";
+import { maskSensitiveDeep, restoreSentinelNodes, stripSensitiveDeep } from "./sensitive-fields";
 
 const app = new Hono();
 
@@ -46,36 +47,9 @@ const createWorkflowBody = z.object({
 
 // ─── Helpers ──────────────────────────────
 
-const SENSITIVE_KEYS = ["apiKey", "api_key", "password", "secret", "token", "apiSecret"];
-const SENSITIVE_KEYS_LOWER = new Set(SENSITIVE_KEYS.map((k) => k.toLowerCase()));
-const MAX_STRIP_DEPTH = 20;
-
-/**
- * Recursively strip sensitive fields (api keys, tokens, passwords) from a
- * value. Walks nested objects and arrays up to MAX_STRIP_DEPTH to guard against
- * pathological inputs. Returns a new structure; input is not mutated.
- */
-function deepStripSensitive(value: unknown, depth = 0): unknown {
-  if (depth >= MAX_STRIP_DEPTH) return value;
-  if (Array.isArray(value)) {
-    return value.map((item) => deepStripSensitive(item, depth + 1));
-  }
-  if (value && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
-      if (SENSITIVE_KEYS_LOWER.has(key.toLowerCase())) {
-        out[key] = "";
-      } else {
-        out[key] = deepStripSensitive(inner, depth + 1);
-      }
-    }
-    return out;
-  }
-  return value;
-}
-
+/** Strip sensitive fields (api keys, tokens, passwords) from exported nodes. */
 function stripApiKeys(nodes: Record<string, unknown>[]): Record<string, unknown>[] {
-  return nodes.map((node) => deepStripSensitive(node) as Record<string, unknown>);
+  return nodes.map((node) => stripSensitiveDeep(node) as Record<string, unknown>);
 }
 
 type WorkflowRow = typeof workflows.$inferSelect;
@@ -95,6 +69,22 @@ function workflowToResponse(row: WorkflowRow): WorkflowResponse {
   };
 }
 
+/**
+ * Mask sensitive config fields (api keys, tokens, passwords) in a workflow
+ * response with the SENTINEL placeholder. Used for every read endpoint
+ * (GET list / GET by id) so secrets are never returned in plaintext. The
+ * PUT endpoint restores real values from the DB when it sees SENTINEL come
+ * back in a request (see restoreSentinelNodes), and workflow execution
+ * (POST /:id/start) does the same before running the workflow, so masking
+ * here does not affect execution.
+ */
+function maskWorkflowResponse(response: WorkflowResponse): WorkflowResponse {
+  return {
+    ...response,
+    nodes: response.nodes.map((node) => maskSensitiveDeep(node)) as WorkflowResponse["nodes"],
+  };
+}
+
 function generateId(): string {
   return crypto.randomUUID();
 }
@@ -102,6 +92,11 @@ function generateId(): string {
 function nowISO(): string {
   return new Date().toISOString();
 }
+
+// Node `type` is used to build a filesystem path when loading plugins
+// (`plugins/{type}/node.ts`), so on import we constrain it to a safe
+// charset to rule out path traversal (`../`, absolute paths, etc.).
+const NODE_TYPE_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
 
 // ─── Routes ───────────────────────────────
 
@@ -136,7 +131,7 @@ app.post("/", zValidator("json", createWorkflowBody), async (c) => {
 // List workflows
 app.get("/", async (c) => {
   const rows = await _db.select().from(workflows).orderBy(desc(workflows.updatedAt));
-  return c.json(rows.map(workflowToResponse));
+  return c.json(rows.map((row) => maskWorkflowResponse(workflowToResponse(row))));
 });
 
 // Get workflow
@@ -144,7 +139,7 @@ app.get("/:id", async (c) => {
   const id = c.req.param("id");
   const [row] = await _db.select().from(workflows).where(eq(workflows.id, id));
   if (!row) return c.json({ detail: "Workflow not found" }, 404);
-  return c.json(workflowToResponse(row));
+  return c.json(maskWorkflowResponse(workflowToResponse(row)));
 });
 
 // Update workflow
@@ -164,14 +159,22 @@ app.put("/:id", async (c) => {
   if (typeof body.name === "string") updates.name = body.name;
   if (body.description === null || typeof body.description === "string")
     updates.description = body.description ?? null;
-  if (body.nodes !== undefined) updates.nodesJson = JSON.stringify(body.nodes);
+  if (body.nodes !== undefined) {
+    // The client (editor/preview) round-trips whatever it received from
+    // GET, which masks sensitive fields with SENTINEL. Restore the real
+    // values from the currently-stored workflow before persisting, so we
+    // never overwrite a real secret with the mask placeholder.
+    const existingNodes = JSON.parse(existing.nodesJson || "[]") as Record<string, unknown>[];
+    const incomingNodes = body.nodes as Record<string, unknown>[];
+    updates.nodesJson = JSON.stringify(restoreSentinelNodes(incomingNodes, existingNodes));
+  }
   if (body.connections !== undefined) updates.connectionsJson = JSON.stringify(body.connections);
   if (body.character !== undefined) updates.characterJson = JSON.stringify(body.character);
 
   await _db.update(workflows).set(updates).where(eq(workflows.id, id));
 
   const [row] = await _db.select().from(workflows).where(eq(workflows.id, id));
-  return c.json(workflowToResponse(row));
+  return c.json(maskWorkflowResponse(workflowToResponse(row)));
 });
 
 // Delete workflow
@@ -210,15 +213,16 @@ app.post("/:id/duplicate", async (c) => {
 });
 
 // Export workflow
+// API keys are always stripped — there is no way to opt out via query
+// string. Exported files are commonly shared/uploaded elsewhere, so this
+// must not be bypassable by the caller.
 app.get("/:id/export", async (c) => {
   const id = c.req.param("id");
-  const excludeApiKeys = c.req.query("exclude_api_keys") !== "false";
 
   const [existing] = await _db.select().from(workflows).where(eq(workflows.id, id));
   if (!existing) return c.json({ detail: "Workflow not found" }, 404);
 
-  let nodes = JSON.parse(existing.nodesJson || "[]");
-  if (excludeApiKeys) nodes = stripApiKeys(nodes);
+  const nodes = stripApiKeys(JSON.parse(existing.nodesJson || "[]"));
 
   return c.json({
     name: existing.name,
@@ -232,13 +236,36 @@ app.get("/:id/export", async (c) => {
 });
 
 // Import workflow
-const importWorkflowBody = z.object({
-  name: z.string().max(256).optional(),
-  description: z.string().max(2048).optional().nullable(),
-  nodes: z.array(z.record(z.string(), z.unknown())).max(500).optional(),
-  connections: z.array(z.record(z.string(), z.unknown())).max(2000).optional(),
-  character: z.record(z.string(), z.unknown()).optional(),
-});
+const importWorkflowBody = z
+  .object({
+    name: z.string().max(256).optional(),
+    description: z.string().max(2048).optional().nullable(),
+    nodes: z.array(z.record(z.string(), z.unknown())).max(500).optional(),
+    connections: z.array(z.record(z.string(), z.unknown())).max(2000).optional(),
+    character: z.record(z.string(), z.unknown()).optional(),
+  })
+  .superRefine((data, ctx) => {
+    // `type` is used verbatim to build a filesystem path when loading the
+    // node's plugin (plugins/{type}/node.ts), so an imported workflow
+    // (e.g. a shared .json file) must not be able to smuggle path
+    // traversal or other unsafe characters through it.
+    data.nodes?.forEach((node, i) => {
+      if (typeof node.id !== "string") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "node.id must be a string",
+          path: ["nodes", i, "id"],
+        });
+      }
+      if (typeof node.type !== "string" || !NODE_TYPE_PATTERN.test(node.type)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "node.type must be a string matching ^[A-Za-z0-9._-]{1,64}$",
+          path: ["nodes", i, "type"],
+        });
+      }
+    });
+  });
 
 app.post("/import", async (c) => {
   let raw: unknown;
@@ -347,7 +374,19 @@ app.post("/:id/start", async (c) => {
     }
   }
 
-  const nodes = (body.nodes as unknown[] | undefined) ?? JSON.parse(existing.nodesJson || "[]");
+  // The editor/preview client sends back whatever it currently holds for
+  // `nodes`, which — if the user never touched a given field this session
+  // — is exactly what GET returned: SENTINEL in place of any real secret.
+  // Restore real values from the stored workflow before handing config to
+  // the executor, so execution always uses the actual API key rather than
+  // the mask placeholder.
+  const nodes =
+    body.nodes !== undefined
+      ? restoreSentinelNodes(
+          body.nodes as Record<string, unknown>[],
+          JSON.parse(existing.nodesJson || "[]") as Record<string, unknown>[],
+        )
+      : JSON.parse(existing.nodesJson || "[]");
   const connections =
     (body.connections as unknown[] | undefined) ?? JSON.parse(existing.connectionsJson || "[]");
   const character =

--- a/tests/routes/settings.test.ts
+++ b/tests/routes/settings.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Global Settings API Routes - Tests
+ *
+ * Tests the PRODUCTION Hono settings routes using an in-memory SQLite
+ * database injected via setDb(). Focus: GET masks sensitive values with a
+ * SENTINEL placeholder, and PUT skips SENTINEL entries so a client
+ * round-tripping a masked value never overwrites a real secret, while an
+ * explicit empty string can still clear one.
+ *
+ * Uses `app.request()` pattern so no running server is needed.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { settingsRoutes, setDb } from "../../apps/server-ts/src/routes/settings";
+import { globalSettings } from "../../apps/server-ts/src/db/schema";
+import { isSensitiveKey, SENTINEL } from "../../apps/server-ts/src/routes/sensitive-fields";
+
+// ─── Test Database ─────────────────────────────────────────────
+
+let sqlite: Database;
+
+function setupTestDb(): ReturnType<typeof drizzle> {
+  sqlite = new Database(":memory:");
+  sqlite.run(`
+    CREATE TABLE IF NOT EXISTS global_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+  return drizzle(sqlite, { schema: { globalSettings } });
+}
+
+function resetDb(): void {
+  sqlite.run("DELETE FROM global_settings");
+}
+
+function teardownDb(): void {
+  sqlite.close();
+}
+
+// ─── Request Helpers ───────────────────────────────────────────
+
+function jsonRequest(method: string, path: string, body?: Record<string, any>): Request {
+  const init: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json" },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+  return new Request(`http://localhost${path}`, init);
+}
+
+async function putSettings(testApp: Hono, body: Record<string, string>) {
+  return testApp.request(jsonRequest("PUT", "/api/settings", body));
+}
+
+async function getSettings(testApp: Hono): Promise<Record<string, string>> {
+  const res = await testApp.request(new Request("http://localhost/api/settings"));
+  return res.json();
+}
+
+// ─── Setup ────────────────────────────────────────────────────
+
+let app: Hono;
+
+beforeAll(() => {
+  const testDb = setupTestDb();
+  setDb(testDb);
+
+  app = new Hono();
+  app.route("/api/settings", settingsRoutes);
+});
+
+beforeEach(() => {
+  resetDb();
+});
+
+afterAll(() => {
+  teardownDb();
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Sensitive key classification
+// ═══════════════════════════════════════════════════════════════
+
+describe("isSensitiveKey classification (canonical setting/config keys)", () => {
+  it("should classify known global-settings API key fields as sensitive", () => {
+    for (const key of [
+      "openai.apiKey",
+      "anthropic.apiKey",
+      "google.apiKey",
+      "mistral.apiKey",
+      "groq.apiKey",
+    ]) {
+      expect(isSensitiveKey(key)).toBe(true);
+    }
+  });
+
+  it("should classify known node config secret fields as sensitive", () => {
+    for (const key of [
+      "apiKey",
+      "api_key",
+      "apiSecret",
+      "llmApiKey",
+      "botToken",
+      "oauthToken",
+      "password",
+      "credential",
+    ]) {
+      expect(isSensitiveKey(key)).toBe(true);
+    }
+  });
+
+  it("should NOT classify non-secret fields as sensitive", () => {
+    for (const key of [
+      "openai.model",
+      "anthropic.model",
+      "ollama.host",
+      "voicevox.host",
+      "coeiroink.host",
+      "sbv2.host",
+      "aivis.host",
+      "model",
+      "host",
+      "maxTokens",
+      "max_tokens",
+      "modelUrl",
+      "channelIds",
+      "filterBots",
+      "temperature",
+    ]) {
+      expect(isSensitiveKey(key)).toBe(false);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// GET /api/settings — masking
+// ═══════════════════════════════════════════════════════════════
+
+describe("GET /api/settings masks sensitive values", () => {
+  it("should mask a non-empty API key with SENTINEL", async () => {
+    await putSettings(app, { "openai.apiKey": "sk-real-secret", "openai.model": "gpt-4o" });
+
+    const data = await getSettings(app);
+    expect(data["openai.apiKey"]).toBe(SENTINEL);
+    expect(data["openai.model"]).toBe("gpt-4o");
+  });
+
+  it("should leave an empty API key as empty (not masked)", async () => {
+    await putSettings(app, { "openai.apiKey": "" });
+
+    const data = await getSettings(app);
+    expect(data["openai.apiKey"]).toBe("");
+  });
+
+  it("should never return a real secret value in the response body", async () => {
+    await putSettings(app, {
+      "anthropic.apiKey": "sk-ant-super-secret",
+      "groq.apiKey": "gsk-super-secret",
+    });
+
+    const res = await app.request(new Request("http://localhost/api/settings"));
+    const raw = await res.text();
+    expect(raw).not.toContain("sk-ant-super-secret");
+    expect(raw).not.toContain("gsk-super-secret");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// PUT /api/settings — sentinel skip / explicit clear
+// ═══════════════════════════════════════════════════════════════
+
+describe("PUT /api/settings skips SENTINEL and preserves the real value", () => {
+  it("should keep the stored API key when PUT sends back SENTINEL", async () => {
+    await putSettings(app, { "openai.apiKey": "sk-original" });
+
+    // Simulate the settings modal: it fetched (getting SENTINEL back),
+    // the user changed an unrelated field, and saves the whole form.
+    const putRes = await putSettings(app, {
+      "openai.apiKey": SENTINEL,
+      "openai.model": "gpt-4o-mini",
+    });
+    expect(putRes.status).toBe(200);
+
+    // Value is preserved in storage — verify by asking for the masked GET
+    // (SENTINEL means "still set") and by checking model did update.
+    const data = await getSettings(app);
+    expect(data["openai.apiKey"]).toBe(SENTINEL);
+    expect(data["openai.model"]).toBe("gpt-4o-mini");
+  });
+
+  it("should allow explicitly clearing an API key with an empty string", async () => {
+    await putSettings(app, { "openai.apiKey": "sk-to-clear" });
+
+    const putRes = await putSettings(app, { "openai.apiKey": "" });
+    expect(putRes.status).toBe(200);
+
+    const data = await getSettings(app);
+    expect(data["openai.apiKey"]).toBe("");
+  });
+
+  it("should not affect non-sensitive keys even if their value happens to equal the sentinel string", async () => {
+    const putRes = await putSettings(app, { "custom.note": SENTINEL });
+    expect(putRes.status).toBe(200);
+
+    const data = await getSettings(app);
+    // Non-sensitive key: literal value is stored, not skipped.
+    expect(data["custom.note"]).toBe(SENTINEL);
+  });
+});

--- a/tests/routes/workflows.test.ts
+++ b/tests/routes/workflows.test.ts
@@ -57,12 +57,19 @@ function teardownDb(): void {
 
 // ─── Mock Executor ─────────────────────────────────────────────
 
+// Captures the args of the most recent startWorkflow() call so tests can
+// assert on what config the executor actually received (real secret vs.
+// sentinel placeholder).
+let lastStartCall: { id: string; data: any; startNodeId?: string | null } | null = null;
+
 const mockExecutor = {
   startWorkflow: async (
-    _id: string,
-    _data: any,
-    _startNodeId?: string | null
-  ) => {},
+    id: string,
+    data: any,
+    startNodeId?: string | null
+  ) => {
+    lastStartCall = { id, data, startNodeId };
+  },
   stopWorkflow: async (_id: string) => {},
   getStatus: (_id: string) => ({ status: "idle" } as Record<string, any>),
   setLogCallback: () => {},
@@ -117,6 +124,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   resetDb();
+  lastStartCall = null;
 });
 
 afterAll(() => {
@@ -418,7 +426,7 @@ describe("Workflow Export / Import", () => {
     expect(exported.nodes[0].config.temperature).toBe(0.7);
   });
 
-  it("should preserve API keys when exclude_api_keys=false", async () => {
+  it("should NOT preserve API keys even when exclude_api_keys=false is passed (query param removed)", async () => {
     const created = await createWorkflowViaApi(app, {
       name: "Keep Keys",
       nodes: [
@@ -430,6 +438,8 @@ describe("Workflow Export / Import", () => {
       ],
     });
 
+    // exclude_api_keys is no longer a supported opt-out — export always
+    // strips secrets regardless of what the caller passes here.
     const res = await app.request(
       new Request(
         `http://localhost/api/workflows/${created.id}/export?exclude_api_keys=false`,
@@ -439,7 +449,7 @@ describe("Workflow Export / Import", () => {
 
     expect(res.status).toBe(200);
     const exported = await res.json();
-    expect(exported.nodes[0].config.apiKey).toBe("sk-keep-me");
+    expect(exported.nodes[0].config.apiKey).toBe("");
   });
 
   it("should strip API keys nested deep inside config (deep strip)", async () => {
@@ -804,10 +814,9 @@ describe("Edge Cases", () => {
 
     // Export
     const exportRes = await app.request(
-      new Request(
-        `http://localhost/api/workflows/${original.id}/export?exclude_api_keys=false`,
-        { method: "GET" }
-      )
+      new Request(`http://localhost/api/workflows/${original.id}/export`, {
+        method: "GET",
+      })
     );
     const exported = await exportRes.json();
 
@@ -878,5 +887,247 @@ describe("Workflow validate body handling", () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.valid).toBeDefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Sensitive field masking (GET) / restoration (PUT, start)
+// ═══════════════════════════════════════════════════════════════
+
+const SENTINEL = "********";
+
+describe("Sensitive field masking on read endpoints", () => {
+  it("should mask a non-empty API key with SENTINEL on GET /:id", async () => {
+    const created = await createWorkflowViaApi(app, {
+      name: "Has Secret",
+      nodes: [
+        {
+          id: "n1",
+          type: "llm-node",
+          config: { model: "gpt-4", apiKey: "sk-real-secret", temperature: 0.7 },
+        },
+      ],
+    });
+
+    const res = await app.request(
+      new Request(`http://localhost/api/workflows/${created.id}`, { method: "GET" })
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.nodes[0].config.apiKey).toBe(SENTINEL);
+    // Non-sensitive fields are untouched
+    expect(data.nodes[0].config.model).toBe("gpt-4");
+    expect(data.nodes[0].config.temperature).toBe(0.7);
+  });
+
+  it("should leave an empty API key empty (not masked) on GET /:id", async () => {
+    const created = await createWorkflowViaApi(app, {
+      name: "No Secret Yet",
+      nodes: [{ id: "n1", type: "llm-node", config: { apiKey: "" } }],
+    });
+
+    const res = await app.request(
+      new Request(`http://localhost/api/workflows/${created.id}`, { method: "GET" })
+    );
+    const data = await res.json();
+    expect(data.nodes[0].config.apiKey).toBe("");
+  });
+
+  it("should not mask non-sensitive fields that merely resemble config, e.g. modelUrl/host", async () => {
+    const created = await createWorkflowViaApi(app, {
+      name: "Avatar Node",
+      nodes: [
+        {
+          id: "n1",
+          type: "avatar-configuration",
+          config: { modelUrl: "https://example.com/model.vrm", host: "localhost", maxTokens: 512 },
+        },
+      ],
+    });
+
+    const res = await app.request(
+      new Request(`http://localhost/api/workflows/${created.id}`, { method: "GET" })
+    );
+    const data = await res.json();
+    expect(data.nodes[0].config.modelUrl).toBe("https://example.com/model.vrm");
+    expect(data.nodes[0].config.host).toBe("localhost");
+    expect(data.nodes[0].config.maxTokens).toBe(512);
+  });
+
+  it("should mask composite sensitive field names (botToken, oauthToken, llmApiKey)", async () => {
+    const created = await createWorkflowViaApi(app, {
+      name: "Composite Keys",
+      nodes: [
+        { id: "n1", type: "discord-chat", config: { botToken: "d-token-real" } },
+        { id: "n2", type: "twitch-chat", config: { oauthToken: "oauth:real" } },
+        { id: "n3", type: "emotion-analyzer", config: { llmApiKey: "sk-real" } },
+      ],
+    });
+
+    const res = await app.request(
+      new Request(`http://localhost/api/workflows/${created.id}`, { method: "GET" })
+    );
+    const data = await res.json();
+    expect(data.nodes[0].config.botToken).toBe(SENTINEL);
+    expect(data.nodes[1].config.oauthToken).toBe(SENTINEL);
+    expect(data.nodes[2].config.llmApiKey).toBe(SENTINEL);
+  });
+
+  it("should mask sensitive fields on GET / (list) as well", async () => {
+    await createWorkflowViaApi(app, {
+      name: "Listed Secret",
+      nodes: [{ id: "n1", type: "llm-node", config: { apiKey: "sk-listed" } }],
+    });
+
+    const res = await app.request(
+      new Request("http://localhost/api/workflows", { method: "GET" })
+    );
+    const data = await res.json();
+    expect(data).toHaveLength(1);
+    expect(data[0].nodes[0].config.apiKey).toBe(SENTINEL);
+  });
+});
+
+describe("PUT restores sentinel values instead of overwriting real secrets", () => {
+  it("should keep the real API key in storage when PUT sends back SENTINEL", async () => {
+    const created = await createWorkflowViaApi(app, {
+      name: "Round Trip Secret",
+      nodes: [{ id: "n1", type: "llm-node", config: { model: "gpt-4", apiKey: "sk-original" } }],
+    });
+
+    // Simulate the editor: it GETs (receiving SENTINEL), the user tweaks
+    // an unrelated field, and PUTs the whole node back including SENTINEL.
+    const putRes = await app.request(
+      jsonRequest("PUT", `/api/workflows/${created.id}`, {
+        nodes: [
+          { id: "n1", type: "llm-node", config: { model: "gpt-4-turbo", apiKey: SENTINEL } },
+        ],
+      })
+    );
+    expect(putRes.status).toBe(200);
+    const putData = await putRes.json();
+    // PUT response itself is also masked
+    expect(putData.nodes[0].config.apiKey).toBe(SENTINEL);
+    // Unrelated field change did take effect
+    expect(putData.nodes[0].config.model).toBe("gpt-4-turbo");
+
+    // The real key must still be usable at execution time.
+    const startRes = await app.request(
+      jsonRequest("POST", `/api/workflows/${created.id}/start`)
+    );
+    expect(startRes.status).toBe(200);
+    expect(lastStartCall?.data.nodes[0].config.apiKey).toBe("sk-original");
+  });
+
+  it("should allow explicitly clearing an API key with an empty string via PUT", async () => {
+    const created = await createWorkflowViaApi(app, {
+      name: "Clearable Secret",
+      nodes: [{ id: "n1", type: "llm-node", config: { apiKey: "sk-to-clear" } }],
+    });
+
+    const putRes = await app.request(
+      jsonRequest("PUT", `/api/workflows/${created.id}`, {
+        nodes: [{ id: "n1", type: "llm-node", config: { apiKey: "" } }],
+      })
+    );
+    expect(putRes.status).toBe(200);
+
+    await app.request(jsonRequest("POST", `/api/workflows/${created.id}/start`));
+    expect(lastStartCall?.data.nodes[0].config.apiKey).toBe("");
+  });
+
+  it("should leave SENTINEL saved literally for a brand-new node with no DB match (documented edge case)", async () => {
+    const created = await createWorkflowViaApi(app, { name: "New Node Edge Case", nodes: [] });
+
+    const putRes = await app.request(
+      jsonRequest("PUT", `/api/workflows/${created.id}`, {
+        nodes: [{ id: "brand-new", type: "llm-node", config: { apiKey: SENTINEL } }],
+      })
+    );
+    expect(putRes.status).toBe(200);
+
+    await app.request(jsonRequest("POST", `/api/workflows/${created.id}/start`));
+    expect(lastStartCall?.data.nodes[0].config.apiKey).toBe(SENTINEL);
+  });
+});
+
+describe("Execution integrity: POST /:id/start always uses real secrets", () => {
+  it("should restore the real API key when start is called with SENTINEL-laden nodes (stale client state)", async () => {
+    const created = await createWorkflowViaApi(app, {
+      name: "Stale Client",
+      nodes: [{ id: "n1", type: "llm-node", config: { apiKey: "sk-actual" } }],
+    });
+
+    // Mimic the editor/preview client: it loaded via GET (masked), never
+    // touched this node's apiKey, and sends the masked value straight
+    // through to /start.
+    const res = await app.request(
+      jsonRequest("POST", `/api/workflows/${created.id}/start`, {
+        nodes: [{ id: "n1", type: "llm-node", config: { apiKey: SENTINEL } }],
+        connections: [],
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(lastStartCall?.data.nodes[0].config.apiKey).toBe("sk-actual");
+  });
+
+  it("should use the stored workflow's real key when start is called with no body", async () => {
+    const created = await createWorkflowViaApi(app, {
+      name: "No Body Start",
+      nodes: [{ id: "n1", type: "llm-node", config: { apiKey: "sk-from-db" } }],
+    });
+
+    const res = await app.request(
+      jsonRequest("POST", `/api/workflows/${created.id}/start`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(lastStartCall?.data.nodes[0].config.apiKey).toBe("sk-from-db");
+  });
+});
+
+describe("Import validation: node type/id charset (path traversal defense)", () => {
+  it("should reject an import with a path-traversal node type", async () => {
+    const res = await app.request(
+      jsonRequest("POST", "/api/workflows/import", {
+        name: "Malicious",
+        nodes: [{ id: "n1", type: "../../../../etc/passwd", config: {} }],
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("should reject an import with a non-string node id", async () => {
+    const res = await app.request(
+      jsonRequest("POST", "/api/workflows/import", {
+        name: "Bad Id",
+        nodes: [{ id: 123, type: "llm-node", config: {} }],
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("should reject an import with an overlong or symbol-laden node type", async () => {
+    const res = await app.request(
+      jsonRequest("POST", "/api/workflows/import", {
+        name: "Bad Type",
+        nodes: [{ id: "n1", type: "llm-node; rm -rf /", config: {} }],
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("should accept an import with a well-formed node type", async () => {
+    const res = await app.request(
+      jsonRequest("POST", "/api/workflows/import", {
+        name: "Good Type",
+        nodes: [{ id: "n1", type: "llm-openai_v2.1-beta", config: {} }],
+      })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.nodes[0].type).toBe("llm-openai_v2.1-beta");
   });
 });

--- a/tests/routes/workflows.test.ts
+++ b/tests/routes/workflows.test.ts
@@ -987,6 +987,52 @@ describe("Sensitive field masking on read endpoints", () => {
     expect(data).toHaveLength(1);
     expect(data[0].nodes[0].config.apiKey).toBe(SENTINEL);
   });
+
+  it("should mask the duplicate response while keeping the real key stored in the DB copy", async () => {
+    const created = await createWorkflowViaApi(app, {
+      name: "Duplicated Secret",
+      nodes: [{ id: "n1", type: "llm-node", config: { apiKey: "sk-dup-secret" } }],
+    });
+
+    // The duplicate response must NOT leak the source workflow's real key
+    // (otherwise duplicate would be a one-call bypass of the GET masking).
+    const dupRes = await app.request(
+      jsonRequest("POST", `/api/workflows/${created.id}/duplicate`)
+    );
+    expect(dupRes.status).toBe(200);
+    const dup = await dupRes.json();
+    expect(dup.nodes[0].config.apiKey).toBe(SENTINEL);
+    expect(JSON.stringify(dup)).not.toContain("sk-dup-secret");
+
+    // ...but the DB copy itself keeps the real key so the duplicate is
+    // immediately runnable.
+    const startRes = await app.request(
+      jsonRequest("POST", `/api/workflows/${dup.id}/start`)
+    );
+    expect(startRes.status).toBe(200);
+    expect(lastStartCall?.data.nodes[0].config.apiKey).toBe("sk-dup-secret");
+  });
+
+  it("should mask create and import responses too (uniform response contract)", async () => {
+    // POST / (create) echoes client-sent data, but the response contract is
+    // still "no secrets in workflow responses".
+    const created = await createWorkflowViaApi(app, {
+      name: "Created Secret",
+      nodes: [{ id: "n1", type: "llm-node", config: { apiKey: "sk-create-secret" } }],
+    });
+    expect(created.nodes[0].config.apiKey).toBe(SENTINEL);
+
+    // POST /import likewise.
+    const importRes = await app.request(
+      jsonRequest("POST", "/api/workflows/import", {
+        name: "Imported Secret",
+        nodes: [{ id: "n1", type: "llm-node", config: { apiKey: "sk-import-secret" } }],
+      })
+    );
+    expect(importRes.status).toBe(200);
+    const imported = await importRes.json();
+    expect(imported.nodes[0].config.apiKey).toBe(SENTINEL);
+  });
 });
 
 describe("PUT restores sentinel values instead of overwriting real secrets", () => {


### PR DESCRIPTION
## 概要

- `GET /api/settings` と `GET /api/workflows`（一覧・`:id`）が、APIキー・トークン・パスワードなどの機微情報を平文でそのまま返していた問題を修正。GETレスポンスでは非空の機微値を `********`（SENTINEL）でマスクして返すようにした。空文字は「未設定」と分かるようそのまま空で返す。
- `PUT /api/settings` と `PUT /api/workflows/:id` は、SENTINEL値を受け取ったフィールドをスキップ（settings）／DBの既存値で復元（workflows、同一ノードID・同一フィールドで照合）してから保存するよう変更。マスク値でユーザーの本物のキーを誤って上書きする事故を防止。空文字は従来どおり明示的なクリア手段として機能する。
- **実行経路の整合性**: ワークフロー実行 `POST /api/workflows/:id/start` は、クライアント（エディタ／プレビュー画面）が送信した `nodes` をそのまま使う経路を持つ。エディタはワークフローを開く際に `GET /api/workflows/:id` で取得したデータ（＝マスク済み）をストアに保持し、ユーザーが触っていないフィールドはそのまま実行時に送信される。マスクだけ入れて `/start` 側を直さないと、実行時に本物のAPIキーの代わりに `********` が送られ、**全ユーザーの実行が壊れる**ため、`/start` にも同じ「SENTINELをDB保存値で復元」ロジックを適用した。global settings（`openai.apiKey` 等）はエンジン側 (`engine/global-settings.ts`) が実行時にDBから直接読み込む経路のため、そちらは元々このマスクの影響を受けない。
- ワークフローエクスポート (`GET /api/workflows/:id/export`) の `exclude_api_keys` クエリパラメータを廃止し、常にAPIキーを除去するよう変更。`?exclude_api_keys=false` でのバイパスができないようにした。
- ワークフローインポート (`POST /api/workflows/import`) の `importWorkflowBody` に検証を追加。`node.type` はプラグインロード時 (`engine/plugin-loader.ts`) にファイルパス構築へ直接使われる (`join(PLUGINS_DIR, nodeType, "node.ts")`) ため、パストラバーサル文字列（`../` など）を防ぐ文字種制限 `^[A-Za-z0-9._-]{1,64}$` を追加。`node.id` も string 必須とした。
- 機微フィールドの判定・マスク・ストリップ・復元ロジックを `apps/server-ts/src/routes/sensitive-fields.ts` に集約し、`settings.ts` / `workflows.ts` で共有。判定は既存キー名（`apiKey`/`api_key`/`password`/`secret`/`token`/`apiSecret`）に加え、`llmApiKey`・`botToken`・`oauthToken`・`openai.apiKey` 等の複合フィールド名も拾う正規表現 `/api[_-]?key|secret|password|credential|token$/i` を追加（`token$` は末尾アンカーのため `maxTokens`/`max_tokens` は誤検知しない）。
- **（レビュー指摘の追加修正）** `POST /api/workflows/:id/duplicate` のレスポンスが複製元の実キーを平文で返しており、GETマスクを duplicate 1回で迂回できてしまう漏れを修正。DB上の複製には実キーを保持したまま（複製後すぐ実行可能）、レスポンスのみマスクする。レスポンス契約統一のため `POST /`（create）と `POST /import` のレスポンスも同様にマスクした（こちらはクライアント送信値のエコーバックで漏洩ではないが、「ワークフローレスポンスに機微情報を含めない」契約に揃えた）。

## 影響範囲

- `apps/server-ts/src/routes/settings.ts`
- `apps/server-ts/src/routes/workflows.ts`
- `apps/server-ts/src/routes/sensitive-fields.ts`（新規）
- `apps/server-ts/src/engine/` および `routes/plugins.ts` は別PRの担当のため変更なし
- フロントエンド (`apps/web`) はコード変更なし。以下を確認済み:
  - `NodeSettings.tsx` / `CustomNode.tsx` の「グローバル設定を使用中」バッジは `config[key]` の空文字判定に依存するが、SENTINELは非空文字列なので実キー設定時と同じ挙動になり、判定ロジックは影響を受けない
  - パスワード型フィールドの一覧表示は既存の `getValueSummary` が値の有無だけで `••••••` を表示する実装済みで、SENTINELでも同様に動作する
  - `PUT /api/workflows/:id` と `PUT /api/settings` のレスポンスはどちらもフロント側で `.error` チェックのみに使われ、返り値のnode/settings値はストアへ書き戻されないため、レスポンスをマスクしてもフロントの状態を壊さない

## 既知の許容エッジケース

- エディタ上でノードを複製すると、複製後の新ノードにSENTINELが載ったまま保存されるケースがある（複製元と新ノードIDが異なるためDB復元の照合に失敗する）。この場合、保存されたSENTINELは実行時に認証エラーとして顕在化し、ユーザーはAPIキーの再入力で回復できる。テストで挙動を明示（`should leave SENTINEL saved literally for a brand-new node with no DB match`）。

## テスト計画

- [x] `tests/routes/settings.test.ts`（新規）: `isSensitiveKey` の分類、GETマスク、PUTでのSENTINELスキップ／明示的な空文字クリア
- [x] `tests/routes/workflows.test.ts`（追加）: GET一覧／単体でのマスク、PUTでの復元とレスポンスマスク、`POST /:id/start` でのSENTINEL復元（本文あり・本文なしの両パターン）、export の `exclude_api_keys=false` バイパス不可、importでのパストラバーサル型 (`../../../../etc/passwd`) ・非string id・不正文字種の拒否
- [x] duplicate レスポンスのマスク＋DB複製に実キーが保存され複製が即実行可能なこと、create/import レスポンスのマスクを検証するテストを追加
- [x] `npm test`（`bun test tests/`）: 265件全てpass
- [x] `apps/server-ts` で `bun run typecheck`: エラーなし
- [x] `apps/server-ts` で `bun run lint`（Biome）: 変更ファイルはクリーン（リポジトリ全体では本PRと無関係な既存のCRLF起因の指摘が出るが、`dev` ブランチでも同数以上発生する既知のWindows環境要因で、本PRの新規混入ではないことを確認済み）
- [x] `apps/web` で `npm run lint`: 0 errors（既存warningのみ、フロントエンド未変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gconfSt4N9ZoBxprKRCsH
