### PR TITLE
fix: エクスポート時にファイル保存ダイアログを表示するように修正

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -20,6 +20,7 @@
     "shell:allow-spawn",
     "shell:allow-stdin-write",
     "updater:default",
-    "process:allow-restart"
+    "process:allow-restart",
+    "dialog:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -155,37 +155,25 @@ fn save_workflow_export(
     content: String,
 ) -> Result<String, String> {
     let safe_name = sanitize_export_filename(&filename);
-    let base_dir = app
-        .path()
-        .download_dir()
-        .or_else(|_| app.path().desktop_dir())
-        .or_else(|_| app.path().app_data_dir())
-        .map_err(|err| format!("failed to resolve export directory: {}", err))?;
-    std::fs::create_dir_all(&base_dir)
-        .map_err(|err| format!("failed to create export directory: {}", err))?;
 
-    let mut target = base_dir.join(&safe_name);
-    if target.exists() {
-        let stem = target
-            .file_stem()
-            .and_then(|v| v.to_str())
-            .unwrap_or("workflow-export");
-        let unique_name = format!("{}-{}.json", stem, chrono_like_timestamp());
-        target = base_dir.join(unique_name);
-    }
+    let file_path = app
+        .dialog()
+        .file()
+        .add_filter("JSON", &["json"])
+        .set_file_name(&safe_name)
+        .blocking_save_file();
+
+    let target = match file_path {
+        Some(path) => path
+            .as_path()
+            .map(|p| p.to_path_buf())
+            .ok_or_else(|| "Invalid file path".to_string())?,
+        None => return Err("cancelled".to_string()),
+    };
 
     std::fs::write(&target, content.as_bytes())
         .map_err(|err| format!("failed to write export file: {}", err))?;
     Ok(target.display().to_string())
-}
-
-fn chrono_like_timestamp() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    secs.to_string()
 }
 
 pub fn run() {

--- a/apps/web/app/(editor)/editor/[id]/client-page.tsx
+++ b/apps/web/app/(editor)/editor/[id]/client-page.tsx
@@ -487,7 +487,6 @@ export default function EditorPage() {
 
   // Export workflow as JSON file
   const handleExport = async () => {
-    // Use API endpoint which strips API keys by default for security
     const response = await api.exportWorkflow(workflowId, { excludeApiKeys: true });
 
     if (response.error) {
@@ -507,17 +506,35 @@ export default function EditorPage() {
       },
     };
 
-    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+    const jsonText = JSON.stringify(exportData, null, 2);
+    const safeName = `${(exportData.workflow.name || 'workflow').replace(/[^a-zA-Z0-9_-]/g, '_')}-${new Date().toISOString().split('T')[0]}.json`;
+    const tauri = (window as Window & { __TAURI_INTERNALS__?: TauriInternals }).__TAURI_INTERNALS__;
+
+    if (typeof tauri?.invoke === 'function') {
+      try {
+        const savedPath = await tauri.invoke('save_workflow_export', {
+          filename: safeName,
+          content: jsonText,
+        });
+        addLog({ level: 'success', message: `Exported: ${String(savedPath)}` });
+      } catch (err) {
+        if (String(err) === 'cancelled') return;
+        addLog({ level: 'error', message: `Export failed: ${err}` });
+      }
+      return;
+    }
+
+    const blob = new Blob([jsonText], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${exportData.workflow.name || 'workflow'}-${new Date().toISOString().split('T')[0]}.json`;
+    a.download = safeName;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
 
-    addLog({ level: 'success', message: 'Workflow exported (API keys excluded for security)' });
+    addLog({ level: 'success', message: 'Workflow exported' });
   };
 
   // Import workflow from JSON file - creates a new workflow

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -207,6 +207,7 @@ export default function HomePage() {
           });
           toast.success(`保存しました: ${String(savedPath)}`);
         } catch (invokeError) {
+          if (String(invokeError) === 'cancelled') return;
           setError(invokeError instanceof Error ? invokeError.message : t('home.saveFailed'));
         }
         return;


### PR DESCRIPTION
## 概要

- デスクトップアプリでワークフローをエクスポートする際、保存先を選択するダイアログが表示されず D:/ に直接保存される問題を修正
- エディタページでもTauri環境ではTauriコマンド経由のエクスポートを使うように統一
- ダイアログでキャンセルした場合のエラー表示を抑制

## 変更内容

- `apps/desktop/src-tauri/src/lib.rs` — `save_workflow_export` をダウンロードフォルダ直接保存からファイル保存ダイアログ経由に変更
- `apps/desktop/src-tauri/capabilities/default.json` — `dialog:default` パーミッションを追加
- `apps/web/app/(editor)/editor/[id]/client-page.tsx` — Tauri環境でTauriコマンドを使ってエクスポートするように修正
- `apps/web/app/page.tsx` — キャンセル時のエラー表示抑制を追加

## テスト計画

- [ ] デスクトップアプリでエクスポートボタンを押すとファイル保存ダイアログが表示される
- [ ] ダイアログで保存先を指定するとそこにJSONファイルが保存される
- [ ] ダイアログをキャンセルするとエラーが表示されない
- [ ] ホームページ・エディタページ両方でエクスポートが動作する
- [ ] Web版（非Tauri）ではブラウザのダウンロードが従来通り動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTpirQp9MYh2M7sCLWJ5dn