### PR TITLE
ci: デスクトップリリースビルドの高速化（Rust キャッシュを main で温める）

### DIFF
--- a/.github/workflows/desktop-cache-warm.yml
+++ b/.github/workflows/desktop-cache-warm.yml
@@ -1,0 +1,65 @@
+name: Desktop Cache Warm
+
+# Desktop Release はタグ push でしか動かないため、タグ ref からは過去のタグで保存した
+# Rust キャッシュを復元できない（GitHub Actions のキャッシュはデフォルトブランチ main か
+# 同一 ref のものしか見えない）。このワークフローが main 上で cargo build を行い、
+# タグビルドが復元できるキャッシュを main に作っておく。
+# shared-key は desktop-release.yml 側の rust-cache と一致させること。
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/desktop/src-tauri/**'
+      - '.github/workflows/desktop-cache-warm.yml'
+  workflow_dispatch:
+
+jobs:
+  warm:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            rust-target: aarch64-apple-darwin
+            cargo-args: '--target aarch64-apple-darwin'
+            sidecar-suffix: '-aarch64-apple-darwin'
+          - platform: macos-latest
+            rust-target: x86_64-apple-darwin
+            cargo-args: '--target x86_64-apple-darwin'
+            sidecar-suffix: '-x86_64-apple-darwin'
+          - platform: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            cargo-args: ''
+            sidecar-suffix: '-x86_64-pc-windows-msvc.exe'
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './apps/desktop/src-tauri -> target'
+          shared-key: desktop-${{ matrix.rust-target }}
+
+      # Tauri のビルドスクリプトが externalBin と resources の実在チェックをするため、
+      # サイドカーとリソースのダミーを置く（キャッシュ生成が目的なので中身は不要）
+      - name: Create placeholder sidecar and resources
+        shell: bash
+        run: |
+          mkdir -p apps/desktop/src-tauri/binaries
+          touch "apps/desktop/src-tauri/binaries/server${{ matrix.sidecar-suffix }}"
+          for dir in plugins templates web-dist; do
+            mkdir -p "apps/desktop/src-tauri/resources/$dir"
+            touch "apps/desktop/src-tauri/resources/$dir/placeholder.txt"
+          done
+
+      - name: Build (warm cache)
+        working-directory: apps/desktop/src-tauri
+        run: cargo build --release ${{ matrix.cargo-args }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -50,10 +52,15 @@ jobs:
         with:
           targets: ${{ matrix.rust-target }}
 
+      # キャッシュは desktop-cache-warm.yml が main 上で生成したものを復元する
+      # （shared-key を一致させること）。タグ ref で保存しても次のタグ run から
+      # 復元できないため、保存はしない（save-if: false）
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
           workspaces: './apps/desktop/src-tauri -> target'
+          shared-key: desktop-${{ matrix.rust-target }}
+          save-if: false
 
       # Build frontend static export
       - name: Install frontend dependencies
@@ -83,7 +90,7 @@ jobs:
 
       # Install Tauri CLI and build
       - name: Install desktop dependencies
-        run: cd apps/desktop && npm install
+        run: cd apps/desktop && npm ci
 
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
## 概要

デスクトップリリースビルド（GA）の高速化。v2.6.1 リリース時の実測で、律速の Windows ジョブが 10.4分、うち cargo コンパイルが約5.5分を占め、ログに `No cache found` が出ていた。

原因: Desktop Release はタグ push でしか動かず、GitHub Actions のキャッシュは「デフォルトブランチ(main) か同一 ref で保存されたもの」しか復元できない。タグ ref で保存したキャッシュは次のタグから見えず、main 上に Rust キャッシュを作るワークフローも無かったため、毎リリースがコールドビルドになっていた。

### 変更内容

- **`desktop-cache-warm.yml` を新規追加**: `apps/desktop/src-tauri/**` に変更がある main への push（+ workflow_dispatch）で、3プラットフォーム分の `cargo build --release` を実行し、タグビルドが復元できるキャッシュを main 上に生成する。Tauri のビルドスクリプトが externalBin / resources の実在チェックをするため、ダミーのサイドカーと placeholder を置いてからビルドする
- **`desktop-release.yml`**:
  - rust-cache に `shared-key: desktop-<target>` を設定し、warm 側のキャッシュを復元
  - `save-if: false` で無駄なキャッシュ保存（毎回約40秒、次回復元不可）を省略
  - `setup-node` に npm キャッシュを追加（Windows で npm ci 44秒 → 短縮）
  - desktop 依存の `npm install` を `npm ci` に変更

rust-cache はロックファイルハッシュを除いた prefix でのフォールバック復元があるため、リリース時のバージョン bump で Cargo.lock が変わってもキャッシュは効く。

期待効果: Windows ジョブ 10.4分 → 6分前後（macOS と同水準）。

### テスト計画

- [x] 両ワークフローの YAML 構文チェック（js-yaml）
- [ ] マージ後、main で `Desktop Cache Warm` を workflow_dispatch で一度実行してキャッシュを生成（dev→main マージ後に実施）
- [ ] 次回リリースのタグビルドで `Restored from cache` と所要時間短縮を確認

### 備考

- warm は src-tauri 変更時にしか走らないため、Rust stable のバージョンが上がるとキーがずれてコールドに戻ることがある。その場合は workflow_dispatch で温め直せばよい
- リリース直前の dev→main マージで src-tauri（Cargo.toml 等）が変わった場合、warm の完走前にタグを push するとその回は prefix フォールバック（前回キャッシュ）での復元になるが、フルコールドよりは十分速い

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQ52Kt5TCZgXUTh4gwvUnm
