### PR TITLE
docs: リリースのバージョン更新対象に desktop package-lock.json を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,11 +316,12 @@ docs: プラグイン開発ガイドを更新
 
 ### 2. バージョン更新
 
-以下のファイルのバージョンを更新 (8箇所全て揃えること):
+以下のファイルのバージョンを更新 (9箇所全て揃えること):
 - `apps/web/package.json`
 - `apps/web/package-lock.json`（ルートの `"version"` と `packages[""]["version"]` の2箇所）
 - `apps/server-ts/package.json`
 - `apps/desktop/package.json`
+- `apps/desktop/package-lock.json`（ルートの `"version"` と `packages[""]["version"]` の2箇所）
 - `apps/desktop/src-tauri/tauri.conf.json`
 - `apps/desktop/src-tauri/Cargo.toml`
 - `apps/desktop/src-tauri/Cargo.lock`（**aituber-flow パッケージの version のみ**）
@@ -330,6 +331,7 @@ docs: プラグイン開発ガイドを更新
 
 ⚠️ 過去のリリースで `apps/desktop/package.json` (2.0.0 のまま) と `Cargo.toml` (パッチずれ) の
 更新漏れが続いていた。Updater 判定の不安定や成果物バージョン文字列の齟齬を防ぐため必ず全て揃える。
+v2.6.1 で `apps/desktop/package-lock.json` が 2.4.0 のまま drift していたのを発見・修正した。PR #297 以降、リリースビルドは `npm ci` を使うため、この lockfile の version 不整合はデスクトップビルドの失敗として顕在化する。
 
 ### 3. コミット＆マージ
 


### PR DESCRIPTION
## 概要
- リリース手順の「バージョン更新」チェックリスト（8箇所）に `apps/desktop/package-lock.json` を追加し、9箇所に更新
- 追加位置は `apps/desktop/package.json` の直後（ルートの `"version"` と `packages[""]["version"]` の2箇所を更新する旨を明記）
- 注意書きに、v2.6.1 で当該 lockfile が 2.4.0 のまま drift していたのを発見・修正した経緯と、PR #297 以降のリリースビルドが `npm ci` を使うため version 不整合がビルド失敗として顕在化する旨を追記

## 背景
過去のリリースで `apps/desktop/package.json` や `Cargo.toml` の更新漏れが起きていたが、`apps/desktop/package-lock.json` はチェックリストに含まれておらず見落とされやすかった。実際に v2.6.1 で drift が発生したため、再発防止のためドキュメントを更新する。

## テスト計画
- [x] ドキュメントのみの変更のため、npm setup・テスト実行は不要