### PR TITLE
chore: 依存関係のセキュリティ整理（hono / shell-quote / openai 調査）

### DIFF
--- a/apps/server-ts/bun.lock
+++ b/apps/server-ts/bun.lock
@@ -10,7 +10,7 @@
         "@hono/zod-validator": "^0.4.0",
         "discord.js": "^14.26.4",
         "drizzle-orm": "^0.45.2",
-        "hono": "^4.12.22",
+        "hono": "^4.12.27",
         "obs-websocket-js": "^5.0.8",
         "openai": "^6.39.0",
         "tmi.js": "^1.8.5",
@@ -167,7 +167,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
-    "hono": ["hono@4.12.22", "", {}, "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw=="],
+    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
 
     "isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
 

--- a/apps/server-ts/package.json
+++ b/apps/server-ts/package.json
@@ -21,7 +21,7 @@
     "@hono/zod-validator": "^0.4.0",
     "discord.js": "^14.26.4",
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.12.22",
+    "hono": "^4.12.27",
     "obs-websocket-js": "^5.0.8",
     "openai": "^6.39.0",
     "tmi.js": "^1.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -423,15 +423,15 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
+      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
+        "shell-quote": "1.8.4",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -1091,9 +1091,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## 概要

依存関係のセキュリティ整理を3点まとめて対応。

### 1. hono を 4.12.22 → 4.12.27 に更新
- `apps/server-ts` の hono が 4.12.22 のまま固定されていた（bun.lock 管理のため Dependabot 対象外）。
- 4.12.25 以降に Windows 向け `serveStatic` のパストラバーサル修正（`%5C` エンコード対応）が含まれる。
- デスクトップ版は `hono/bun` の `serveStatic` で静的配信しているため該当。
- `apps/server-ts/package.json` の `hono` を `^4.12.27` に更新し、`bun install` で `bun.lock` を再生成。

### 2. shell-quote の critical 脆弱性を解消（GHSA-w7jw-789q-3m8p / CVE-2026-9277）
- **引き込み元**: ルート `package-lock.json` の推移的 devDependency。`concurrently@9.2.1` → `shell-quote@1.8.3`（`npm ls shell-quote` で確認）。
- `quote()` が object の `.op` 値の改行をエスケープせず、シェルコマンドインジェクションに繋がる脆弱性（脆弱範囲 `>=1.1.0 <=1.8.3`、修正版 `1.8.4`）。
- **対応方法**: `npm audit fix`（`--force` は未使用）を実行したところ、`concurrently` が `^9.1.2` の範囲内で `9.2.1 → 9.2.3` に上がり、それに伴い `shell-quote` も `1.8.3 → 1.8.4`（パッチ版）に更新された。`overrides` の追加は不要だった。
- `package.json` の `concurrently` の指定（`^9.1.2`）は変更なし。`package-lock.json` のみ更新。

### 3. ルート `openai@4.104.0` は削除しない（実際に使用されている）
- 当初「未使用では」という調査結果だったが、実際には `plugins/openai-llm`, `plugins/openai-tts`, `plugins/groq-llm`, `plugins/mistral-llm` が `import OpenAI from "openai"` している。
- `plugins/` は独自の `node_modules` を持たず、`apps/server-ts` の子ディレクトリでもないため、Node/Bun のモジュール解決はプラグインディレクトリから上位へ辿り、**ルートの `node_modules/openai`（v4.104.0）に解決される**。実際に `import.meta.resolve("openai")` を `plugins/openai-llm/` から実行して確認済み（`apps/server-ts/node_modules/openai@6.39.0` ではなくルートの v4 が解決された）。
- そのため **ルートの `openai` を削除するとプラグインの読み込みが壊れる**。今回は削除しない。
- 参考: root の他の依存（`@anthropic-ai/sdk`, `@google/generative-ai`, `discord.js`, `obs-websocket-js`, `tmi.js`）も同じパターンで、各プラグインが import する SDK をルートに重複して持たせる構成になっている（意図的と思われる）。
- `openai@4 → 6`（`apps/server-ts` 側と揃える）への更新可否は今回未対応。基本的な API サーフェス（コンストラクタ、`chat.completions.create`）は両バージョンで大きくは変わらず移行の難易度は低そうに見えるが、メジャー2段階のジャンプでありプラグイン側の動作確認が必要なため、別 PR での対応を推奨。

### スコープ外（今回対応なし）
- `npm audit` に残る `undici`（high）/ `discord.js`, `@discordjs/rest`, `@discordjs/ws`（moderate）は `discord.js@14.26.4` の推移的依存。修正には `npm audit fix --force` による `discord.js@13.17.1` へのダウングレード（破壊的変更）が必要なため、今回は対象外（別途要検討）。

## npm audit 比較（ルート）

| | before | after |
|---|---|---|
| critical | 2 (shell-quote, concurrently) | 0 |
| high | 1 (undici) | 1 (undici, 対象外) |
| moderate | 3 (discord.js 系) | 3 (discord.js 系, 対象外) |
| total | 6 | 4 |

## テスト計画

- [x] `apps/server-ts` で `bun install`（hono 更新反映）
- [x] ルートで `npm audit fix`（shell-quote 更新反映、`--force` 未使用）
- [x] `npm test`（`bun test tests/ --verbose`）: **331 pass / 0 fail**（ログに見えるエラーはエラーハンドリングを検証するテスト自身が意図的に投げているもの）
- [x] `npm run lint`（web + server）: 新規エラーなし。server 側の 26 errors / 20 warnings は dev ブランチのベースラインと同一件数で確認済み（本 PR による新規混入なし）。web 側は 0 errors / 12 warnings（すべて既存の未使用変数・hooks 依存警告）
- [x] `git grep` で `openai` の import 元をプラグイン単位で確認し、`import.meta.resolve` で実際の解決先がルート `node_modules` であることを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)