### PR TITLE
記憶システムのUX改善: テーブル名セレクター化 & 検索タイプ連動表示

### DIFF
--- a/apps/server-ts/src/db/database.ts
+++ b/apps/server-ts/src/db/database.ts
@@ -60,11 +60,26 @@ const CREATE_MEMORIES_INDEX_SQL = `
   ON memories (workflow_id, table_name)
 `;
 
+const CREATE_MEMORY_TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS memory_tables (
+    workflow_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL
+  )
+`;
+
+const CREATE_MEMORY_TABLES_INDEX_SQL = `
+  CREATE UNIQUE INDEX IF NOT EXISTS memory_tables_workflow_name_idx
+  ON memory_tables (workflow_id, name)
+`;
+
 export function initDb(): void {
   sqlite.exec(CREATE_TABLE_SQL);
   sqlite.exec(CREATE_GLOBAL_SETTINGS_SQL);
   sqlite.exec(CREATE_MEMORIES_SQL);
   sqlite.exec(CREATE_MEMORIES_INDEX_SQL);
+  sqlite.exec(CREATE_MEMORY_TABLES_SQL);
+  sqlite.exec(CREATE_MEMORY_TABLES_INDEX_SQL);
 }
 
 // ─── JSON helpers ───────────────────────────────────────────────

--- a/apps/server-ts/src/db/memories-repository.ts
+++ b/apps/server-ts/src/db/memories-repository.ts
@@ -14,7 +14,7 @@
 
 import { and, desc, eq, sql } from "drizzle-orm";
 import { db as defaultDb } from "./database";
-import { memories } from "./schema";
+import { memories, memoryTables } from "./schema";
 
 const DEFAULT_SEARCH_LIMIT = 50;
 
@@ -94,13 +94,47 @@ export async function searchMemories(params: SearchMemoriesParams): Promise<Memo
     .limit(limit ?? DEFAULT_SEARCH_LIMIT);
 }
 
-/** List the distinct table names that have at least one memory for a workflow. */
+/**
+ * List the table names available for a workflow: the union of tables
+ * explicitly registered (via `createMemoryTable`, e.g. empty tables created
+ * ahead of use) and tables that already hold at least one memory row.
+ * Deduplicated and sorted for a stable UI order.
+ */
 export async function listMemoryTables(workflowId: string): Promise<string[]> {
-  const rows = await _db
-    .selectDistinct({ tableName: memories.tableName })
-    .from(memories)
-    .where(eq(memories.workflowId, workflowId));
-  return rows.map((row) => row.tableName);
+  const [registered, used] = await Promise.all([
+    _db
+      .select({ name: memoryTables.name })
+      .from(memoryTables)
+      .where(eq(memoryTables.workflowId, workflowId)),
+    _db
+      .selectDistinct({ tableName: memories.tableName })
+      .from(memories)
+      .where(eq(memories.workflowId, workflowId)),
+  ]);
+
+  const names = new Set<string>();
+  for (const row of registered) names.add(row.name);
+  for (const row of used) names.add(row.tableName);
+  return Array.from(names).sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Register a memory table name for a workflow (idempotent — if the name is
+ * already registered, this is a no-op and the existing name is returned).
+ */
+export async function createMemoryTable(workflowId: string, name: string): Promise<string> {
+  const [existing] = await _db
+    .select({ name: memoryTables.name })
+    .from(memoryTables)
+    .where(and(eq(memoryTables.workflowId, workflowId), eq(memoryTables.name, name)));
+  if (existing) return existing.name;
+
+  await _db.insert(memoryTables).values({
+    workflowId,
+    name,
+    createdAt: nowISO(),
+  });
+  return name;
 }
 
 /** Delete all memories for a workflow, optionally scoped to a single table. */
@@ -108,6 +142,10 @@ export async function deleteMemories(workflowId: string, tableName?: string): Pr
   const conditions = [eq(memories.workflowId, workflowId)];
   if (tableName) conditions.push(eq(memories.tableName, tableName));
   await _db.delete(memories).where(and(...conditions));
+
+  const registryConditions = [eq(memoryTables.workflowId, workflowId)];
+  if (tableName) registryConditions.push(eq(memoryTables.name, tableName));
+  await _db.delete(memoryTables).where(and(...registryConditions));
 }
 
 /**

--- a/apps/server-ts/src/db/schema.ts
+++ b/apps/server-ts/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { blob, index, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { blob, index, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const workflows = sqliteTable("workflows", {
   id: text("id").primaryKey(),
@@ -32,5 +32,25 @@ export const memories = sqliteTable(
   },
   (table) => ({
     workflowTableIdx: index("memories_workflow_table_idx").on(table.workflowId, table.tableName),
+  }),
+);
+
+/**
+ * Registry of memory table names per workflow. Lets the node-config UI offer
+ * a selector instead of free-text input (avoids typo-driven table splits),
+ * while still allowing empty tables to exist before any memory is saved.
+ */
+export const memoryTables = sqliteTable(
+  "memory_tables",
+  {
+    workflowId: text("workflow_id").notNull(),
+    name: text("name").notNull(),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => ({
+    workflowNameIdx: uniqueIndex("memory_tables_workflow_name_idx").on(
+      table.workflowId,
+      table.name,
+    ),
   }),
 );

--- a/apps/server-ts/src/routes/memories.ts
+++ b/apps/server-ts/src/routes/memories.ts
@@ -126,20 +126,16 @@ app.get("/:workflowId/memories/tables", async (c) => {
 // Register a new (possibly empty) memory table name. Idempotent: returns
 // 200 with the existing name if it's already registered, so the node-config
 // UI can call this unconditionally without checking first.
-app.post(
-  "/:workflowId/memories/tables",
-  zValidator("json", createMemoryTableBody),
-  async (c) => {
-    const workflowId = c.req.param("workflowId");
-    if (!(await workflowExists(workflowId))) {
-      return c.json({ detail: "Workflow not found" }, 404);
-    }
+app.post("/:workflowId/memories/tables", zValidator("json", createMemoryTableBody), async (c) => {
+  const workflowId = c.req.param("workflowId");
+  if (!(await workflowExists(workflowId))) {
+    return c.json({ detail: "Workflow not found" }, 404);
+  }
 
-    const { name } = c.req.valid("json");
-    const created = await memoriesRepository.createMemoryTable(workflowId, name);
-    return c.json({ name: created });
-  },
-);
+  const { name } = c.req.valid("json");
+  const created = await memoriesRepository.createMemoryTable(workflowId, name);
+  return c.json({ name: created });
+});
 
 // Delete all memories for a workflow (optionally scoped to one table)
 app.delete("/:workflowId/memories", async (c) => {

--- a/apps/server-ts/src/routes/memories.ts
+++ b/apps/server-ts/src/routes/memories.ts
@@ -64,6 +64,16 @@ const createMemoryBody = z.object({
   content: z.string({ required_error: "content is required" }).min(1),
 });
 
+const MAX_TABLE_NAME_LENGTH = 64;
+
+const createMemoryTableBody = z.object({
+  name: z
+    .string({ required_error: "name is required" })
+    .trim()
+    .min(1, "name must not be empty")
+    .max(MAX_TABLE_NAME_LENGTH, `name must be at most ${MAX_TABLE_NAME_LENGTH} characters`),
+});
+
 // ─── Routes ───────────────────────────────
 
 // List memories (recent or keyword search)
@@ -102,7 +112,7 @@ app.post("/:workflowId/memories", zValidator("json", createMemoryBody), async (c
   return c.json(memoryToResponse(row), 201);
 });
 
-// List distinct table names for a workflow
+// List table names for a workflow (registered tables ∪ tables already in use)
 app.get("/:workflowId/memories/tables", async (c) => {
   const workflowId = c.req.param("workflowId");
   if (!(await workflowExists(workflowId))) {
@@ -112,6 +122,24 @@ app.get("/:workflowId/memories/tables", async (c) => {
   const tableNames = await memoriesRepository.listMemoryTables(workflowId);
   return c.json(tableNames);
 });
+
+// Register a new (possibly empty) memory table name. Idempotent: returns
+// 200 with the existing name if it's already registered, so the node-config
+// UI can call this unconditionally without checking first.
+app.post(
+  "/:workflowId/memories/tables",
+  zValidator("json", createMemoryTableBody),
+  async (c) => {
+    const workflowId = c.req.param("workflowId");
+    if (!(await workflowExists(workflowId))) {
+      return c.json({ detail: "Workflow not found" }, 404);
+    }
+
+    const { name } = c.req.valid("json");
+    const created = await memoriesRepository.createMemoryTable(workflowId, name);
+    return c.json({ name: created });
+  },
+);
 
 // Delete all memories for a workflow (optionally scoped to one table)
 app.delete("/:workflowId/memories", async (c) => {

--- a/apps/web/components/editor/CustomNode.tsx
+++ b/apps/web/components/editor/CustomNode.tsx
@@ -488,7 +488,7 @@ function TextareaEditorPopover({
 // Complex field types that cannot be edited inline
 const COMPLEX_FIELD_TYPES = new Set([
   'prompt-builder', 'expression-list', 'animation-file',
-  'model-file', 'png-expression-map', 'input-list',
+  'model-file', 'png-expression-map', 'input-list', 'memory-table',
 ]);
 
 // Get a summary string for a field value (used in collapsed view)

--- a/apps/web/components/panels/MemoryViewer.tsx
+++ b/apps/web/components/panels/MemoryViewer.tsx
@@ -29,6 +29,9 @@ export default function MemoryViewer({ workflowId, onClose }: MemoryViewerProps)
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [pendingDeleteAll, setPendingDeleteAll] = useState(false);
   const deleteAllTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const [addingTable, setAddingTable] = useState(false);
+  const [newTableName, setNewTableName] = useState('');
+  const [creatingTable, setCreatingTable] = useState(false);
 
   const loadTables = useCallback(async () => {
     const response = await api.listMemoryTables(workflowId);
@@ -57,6 +60,29 @@ export default function MemoryViewer({ workflowId, onClose }: MemoryViewerProps)
     loadTables();
     loadMemories();
   }, [loadTables, loadMemories]);
+
+  const handleCreateTable = async () => {
+    const name = newTableName.trim();
+    if (!name) {
+      toast.warning(t('memories.tableNameRequired'));
+      return;
+    }
+
+    setCreatingTable(true);
+    const response = await api.createMemoryTable(workflowId, name);
+    setCreatingTable(false);
+
+    if (response.error) {
+      toast.error(t('memories.createTableError') + response.error);
+      return;
+    }
+
+    toast.success(t('memories.createTableSuccess'));
+    setNewTableName('');
+    setAddingTable(false);
+    setSelectedTable(response.data?.name ?? name);
+    await loadTables();
+  };
 
   // Initial load + reload when the panel is opened for a different workflow
   useEffect(() => {
@@ -198,6 +224,18 @@ export default function MemoryViewer({ workflowId, onClose }: MemoryViewerProps)
             ))}
           </select>
 
+          <button
+            onClick={() => setAddingTable((prev) => !prev)}
+            className="w-7 h-7 flex-shrink-0 rounded-lg flex items-center justify-center text-fg-dim hover:text-fg hover:bg-hover transition-colors"
+            title={t('memories.addTable')}
+            aria-label={t('memories.addTable')}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+          </button>
+
           {!loading && (
             <span className="text-xs text-fg-faint whitespace-nowrap">
               {memoriesList.length} {t('memories.itemCount')}
@@ -236,6 +274,47 @@ export default function MemoryViewer({ workflowId, onClose }: MemoryViewerProps)
             {t('memories.deleteAll')}
           </button>
         </div>
+
+        {/* Inline "create table" row */}
+        {addingTable && (
+          <div
+            className="px-6 py-3 flex items-center gap-2 flex-shrink-0"
+            style={{ borderBottom: '1px solid var(--border-subtle)' }}
+          >
+            <input
+              type="text"
+              autoFocus
+              value={newTableName}
+              onChange={(e) => setNewTableName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleCreateTable();
+                if (e.key === 'Escape') {
+                  setAddingTable(false);
+                  setNewTableName('');
+                }
+              }}
+              placeholder={t('memories.newTablePlaceholder')}
+              className="flex-1 px-3 py-1.5 rounded-lg text-sm text-fg outline-none"
+              style={{ background: 'var(--elevated)', border: '1px solid var(--border)' }}
+            />
+            <button
+              onClick={handleCreateTable}
+              disabled={creatingTable}
+              className="px-3 py-1.5 rounded-lg text-xs text-emerald-400 hover:bg-hover transition-colors disabled:opacity-40"
+            >
+              {t('memories.createTable')}
+            </button>
+            <button
+              onClick={() => {
+                setAddingTable(false);
+                setNewTableName('');
+              }}
+              className="px-3 py-1.5 rounded-lg text-xs text-fg-muted hover:bg-hover transition-colors"
+            >
+              {t('memories.cancel')}
+            </button>
+          </div>
+        )}
 
         {/* Body */}
         <div className="flex-1 overflow-y-auto min-h-[240px]">

--- a/apps/web/components/panels/NodeSettings.tsx
+++ b/apps/web/components/panels/NodeSettings.tsx
@@ -85,6 +85,142 @@ function PasswordField({
   );
 }
 
+// Memory table selector: fetches the registered/in-use table names for the
+// current workflow and offers an inline "create new table" flow so typos
+// can't silently split a memory-save/memory-search node onto a new table.
+interface MemoryTableFieldProps {
+  value: string;
+  workflowId: string | null;
+  onChange: (newValue: string) => void;
+  style?: React.CSSProperties;
+}
+
+const MEMORY_TABLE_CREATE_NEW = "__create_new__";
+
+function MemoryTableField({ value, workflowId, onChange, style }: MemoryTableFieldProps) {
+  const { t } = useTranslation();
+  const [tables, setTables] = useState<string[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [newTableName, setNewTableName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const loadTables = useCallback(async () => {
+    if (!workflowId) return;
+    const response = await api.listMemoryTables(workflowId);
+    if (response.data) {
+      setTables(response.data);
+    } else if (response.error) {
+      toast.error(t("settings.memoryTableLoadFailed") + response.error);
+    }
+  }, [workflowId, t]);
+
+  useEffect(() => {
+    loadTables();
+  }, [loadTables]);
+
+  // Ensure the node's current value is always selectable, even if it isn't
+  // (yet) registered or used — important for existing workflows saved
+  // before this selector existed (backward compatibility).
+  const options = value && !tables.includes(value) ? [value, ...tables] : tables;
+
+  const handleCreate = async () => {
+    if (!workflowId) return;
+    const name = newTableName.trim();
+    if (!name) return;
+
+    setSubmitting(true);
+    const response = await api.createMemoryTable(workflowId, name);
+    setSubmitting(false);
+
+    if (response.error) {
+      toast.error(t("settings.memoryTableCreateFailed") + response.error);
+      return;
+    }
+
+    const createdName = response.data?.name ?? name;
+    setCreating(false);
+    setNewTableName("");
+    await loadTables();
+    onChange(createdName);
+  };
+
+  if (creating) {
+    return (
+      <div className="flex gap-2">
+        <input
+          type="text"
+          autoFocus
+          value={newTableName}
+          onChange={(e) => setNewTableName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleCreate();
+            if (e.key === "Escape") {
+              setCreating(false);
+              setNewTableName("");
+            }
+          }}
+          placeholder={t("settings.memoryTableNewNamePlaceholder")}
+          style={{ ...style, flex: 1 }}
+        />
+        <button
+          onClick={handleCreate}
+          disabled={submitting || !newTableName.trim()}
+          style={{
+            padding: "8px 10px",
+            borderRadius: "6px",
+            border: "1px solid rgba(16, 185, 129, 0.5)",
+            background: "rgba(16, 185, 129, 0.2)",
+            color: "#fff",
+            fontSize: "12px",
+            cursor: submitting ? "wait" : "pointer",
+          }}
+        >
+          {t("settings.memoryTableCreate")}
+        </button>
+        <button
+          onClick={() => {
+            setCreating(false);
+            setNewTableName("");
+          }}
+          style={{
+            padding: "8px 10px",
+            borderRadius: "6px",
+            border: "1px solid var(--border)",
+            background: "rgba(0,0,0,0.3)",
+            color: "#fff",
+            fontSize: "12px",
+            cursor: "pointer",
+          }}
+        >
+          {t("settings.memoryTableCancel")}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <select
+      value={value ?? ""}
+      onChange={(e) => {
+        if (e.target.value === MEMORY_TABLE_CREATE_NEW) {
+          setCreating(true);
+          return;
+        }
+        onChange(e.target.value);
+      }}
+      style={style}
+    >
+      <option value="">{t("settings.memoryTableSelectPlaceholder")}</option>
+      {options.map((tableName) => (
+        <option key={tableName} value={tableName}>
+          {tableName}
+        </option>
+      ))}
+      <option value={MEMORY_TABLE_CREATE_NEW}>{t("settings.memoryTableCreateNew")}</option>
+    </select>
+  );
+}
+
 // Separate component for input-list field to properly use hooks
 interface InputListFieldProps {
   value: string[];
@@ -1833,7 +1969,7 @@ function normalizeLegacyConfig(
 }
 
 export default function NodeSettings() {
-  const { selectedNodeId, nodes, updateNode, removeNode } = useWorkflowStore();
+  const { selectedNodeId, nodes, updateNode, removeNode, workflowId } = useWorkflowStore();
   const { t } = useTranslation();
   const { settings: globalSettingsValues, loaded: globalSettingsLoaded, fetchSettings: fetchGlobalSettings } = useSettingsStore();
   const [showOverrides, setShowOverrides] = useState(false);
@@ -2593,6 +2729,16 @@ export default function NodeSettings() {
             value={(value ?? field.defaultValue ?? "") as string}
             onChange={(newValue) => handleChange(field.key, newValue)}
             placeholder={field.placeholder}
+            style={inputStyle}
+          />
+        );
+
+      case "memory-table":
+        return (
+          <MemoryTableField
+            value={(value ?? field.defaultValue ?? "") as string}
+            workflowId={workflowId}
+            onChange={(newValue) => handleChange(field.key, newValue)}
             style={inputStyle}
           />
         );

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -252,6 +252,17 @@ class ApiClient {
     return this.request<string[]>(`/api/workflows/${workflowId}/memories/tables`);
   }
 
+  // Idempotent: returns the existing table if `name` is already registered.
+  async createMemoryTable(
+    workflowId: string,
+    name: string
+  ): Promise<ApiResponse<{ name: string }>> {
+    return this.request<{ name: string }>(`/api/workflows/${workflowId}/memories/tables`, {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    });
+  }
+
   async deleteMemory(workflowId: string, id: string): Promise<ApiResponse<{ status: string }>> {
     return this.request<{ status: string }>(`/api/workflows/${workflowId}/memories/${id}`, {
       method: 'DELETE',

--- a/apps/web/lib/configUtils.ts
+++ b/apps/web/lib/configUtils.ts
@@ -38,6 +38,7 @@ function mapFieldType(manifestType: ConfigField['type']): NodeField['type'] {
     case 'animation-file':
     case 'model-file':
     case 'png-expression-map':
+    case 'memory-table':
       return manifestType;
     default:
       return 'text';

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -134,7 +134,8 @@ export interface ConfigField {
     | 'expression-list'
     | 'animation-file'
     | 'model-file'
-    | 'png-expression-map';
+    | 'png-expression-map'
+    | 'memory-table';
   label: string;
   description?: string;
   required?: boolean;
@@ -168,7 +169,8 @@ export interface NodeField {
     | 'input-list'
     | 'expression-list'
     | 'password'
-    | 'png-expression-map';
+    | 'png-expression-map'
+    | 'memory-table';
   label: string;
   placeholder?: string;
   options?: { label: string; value: string | number }[];

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -86,7 +86,14 @@
     "expressionIdPlaceholder": "Expression ID (e.g., smug)",
     "imageFilenamePlaceholder": "Image filename (e.g., smug.png)",
     "descriptionForLlm": "Description for LLM analysis",
-    "descriptionForLlmPlaceholder": "Description for LLM (e.g., 'Self-satisfied, proud, confident')"
+    "descriptionForLlmPlaceholder": "Description for LLM (e.g., 'Self-satisfied, proud, confident')",
+    "memoryTableSelectPlaceholder": "Select a table...",
+    "memoryTableCreateNew": "+ Create new table",
+    "memoryTableNewNamePlaceholder": "New table name",
+    "memoryTableCreate": "Create",
+    "memoryTableCancel": "Cancel",
+    "memoryTableCreateFailed": "Failed to create table: ",
+    "memoryTableLoadFailed": "Failed to load tables: "
   },
   "logs": {
     "title": "Execution Log",
@@ -510,7 +517,14 @@
     "emptyFiltered": "No memories in this table",
     "unsavedWorkflow": "Save the workflow before viewing memories",
     "close": "Close",
-    "itemCount": "memories"
+    "itemCount": "memories",
+    "addTable": "Add table",
+    "newTablePlaceholder": "New table name",
+    "createTable": "Create",
+    "cancel": "Cancel",
+    "tableNameRequired": "Enter a table name",
+    "createTableSuccess": "Table created",
+    "createTableError": "Failed to create table: "
   },
   "search": {
     "placeholder": "Search nodes...",

--- a/apps/web/locales/ja.json
+++ b/apps/web/locales/ja.json
@@ -86,7 +86,14 @@
     "expressionIdPlaceholder": "表情ID (例: smug)",
     "imageFilenamePlaceholder": "画像ファイル名 (例: smug.png)",
     "descriptionForLlm": "LLM分析用の説明",
-    "descriptionForLlmPlaceholder": "LLMへの説明 (例: '得意げ、自信満々')"
+    "descriptionForLlmPlaceholder": "LLMへの説明 (例: '得意げ、自信満々')",
+    "memoryTableSelectPlaceholder": "テーブルを選択...",
+    "memoryTableCreateNew": "＋ 新しいテーブルを作成",
+    "memoryTableNewNamePlaceholder": "新しいテーブル名",
+    "memoryTableCreate": "作成",
+    "memoryTableCancel": "キャンセル",
+    "memoryTableCreateFailed": "テーブルの作成に失敗しました: ",
+    "memoryTableLoadFailed": "テーブル一覧の読み込みに失敗しました: "
   },
   "logs": {
     "title": "実行ログ",
@@ -510,7 +517,14 @@
     "emptyFiltered": "このテーブルにはメモリーがありません",
     "unsavedWorkflow": "メモリーを見るにはワークフローを保存してください",
     "close": "閉じる",
-    "itemCount": "件"
+    "itemCount": "件",
+    "addTable": "テーブルを追加",
+    "newTablePlaceholder": "新しいテーブル名",
+    "createTable": "作成",
+    "cancel": "キャンセル",
+    "tableNameRequired": "テーブル名を入力してください",
+    "createTableSuccess": "テーブルを作成しました",
+    "createTableError": "テーブルの作成に失敗しました: "
   },
   "search": {
     "placeholder": "ノードを検索...",

--- a/plugins/memory-save/manifest.json
+++ b/plugins/memory-save/manifest.json
@@ -33,7 +33,7 @@
   },
   "config": {
     "tableName": {
-      "type": "string",
+      "type": "memory-table",
       "label": "テーブル名",
       "description": "記憶の保存先テーブル名",
       "default": "default",

--- a/plugins/memory-search/manifest.json
+++ b/plugins/memory-search/manifest.json
@@ -44,7 +44,7 @@
   },
   "config": {
     "tableName": {
-      "type": "string",
+      "type": "memory-table",
       "label": "テーブル名",
       "description": "検索対象のテーブル名",
       "default": "default",
@@ -73,7 +73,8 @@
       "type": "string",
       "label": "デフォルトクエリ",
       "description": "入力ポートが空の時に使用するクエリ（キーワード検索時）",
-      "default": ""
+      "default": "",
+      "showWhen": { "key": "searchType", "value": "keyword" }
     }
   }
 }

--- a/tests/routes/memories.test.ts
+++ b/tests/routes/memories.test.ts
@@ -18,7 +18,7 @@ import { Hono } from "hono";
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { memoryRoutes, setDb } from "../../apps/server-ts/src/routes/memories";
-import { memories, workflows } from "../../apps/server-ts/src/db/schema";
+import { memories, memoryTables, workflows } from "../../apps/server-ts/src/db/schema";
 
 // ─── Test Database ─────────────────────────────────────────────
 
@@ -49,11 +49,23 @@ function setupTestDb(): ReturnType<typeof drizzle> {
       updated_at TEXT NOT NULL
     )
   `);
-  return drizzle(sqlite, { schema: { workflows, memories } });
+  sqlite.run(`
+    CREATE TABLE IF NOT EXISTS memory_tables (
+      workflow_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    )
+  `);
+  sqlite.run(`
+    CREATE UNIQUE INDEX IF NOT EXISTS memory_tables_workflow_name_idx
+    ON memory_tables (workflow_id, name)
+  `);
+  return drizzle(sqlite, { schema: { workflows, memories, memoryTables } });
 }
 
 function resetDb(): void {
   sqlite.run("DELETE FROM memories");
+  sqlite.run("DELETE FROM memory_tables");
   sqlite.run("DELETE FROM workflows");
 }
 
@@ -95,6 +107,17 @@ async function insertMemory(
     [id, workflowId, tableName, content, createdAt, createdAt],
   );
   return id;
+}
+
+async function insertMemoryTable(
+  workflowId: string,
+  name: string,
+  createdAt: string = NOW,
+): Promise<void> {
+  sqlite.run(
+    `INSERT INTO memory_tables (workflow_id, name, created_at) VALUES (?, ?, ?)`,
+    [workflowId, name, createdAt],
+  );
 }
 
 // ─── Setup ────────────────────────────────────────────────────
@@ -306,6 +329,111 @@ describe("GET /:workflowId/memories/tables", () => {
     const data = await res.json();
     expect(data.sort()).toEqual(["table-a", "table-b"]);
   });
+
+  it("returns the union of registered tables and tables already in use, deduplicated", async () => {
+    await insertWorkflow("wf-1");
+    await insertMemory("wf-1", "table-a", "a1");
+    await insertMemoryTable("wf-1", "table-a"); // registered AND in use
+    await insertMemoryTable("wf-1", "table-empty"); // registered, never used
+
+    const res = await app.request(jsonRequest("GET", "/api/workflows/wf-1/memories/tables"));
+    const data = await res.json();
+    expect(data.sort()).toEqual(["table-a", "table-empty"]);
+  });
+
+  it("does not leak table names registered under a different workflow", async () => {
+    await insertWorkflow("wf-1");
+    await insertWorkflow("wf-2");
+    await insertMemoryTable("wf-2", "other-workflow-table");
+
+    const res = await app.request(jsonRequest("GET", "/api/workflows/wf-1/memories/tables"));
+    const data = await res.json();
+    expect(data).toEqual([]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// POST /:workflowId/memories/tables
+// ═══════════════════════════════════════════════════════════════
+
+describe("POST /:workflowId/memories/tables", () => {
+  it("returns 404 when the workflow does not exist", async () => {
+    const res = await app.request(
+      jsonRequest("POST", "/api/workflows/does-not-exist/memories/tables", {
+        name: "new-table",
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("registers a new table and it shows up in the tables list", async () => {
+    await insertWorkflow("wf-1");
+
+    const res = await app.request(
+      jsonRequest("POST", "/api/workflows/wf-1/memories/tables", { name: "new-table" }),
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.name).toBe("new-table");
+
+    const listRes = await app.request(jsonRequest("GET", "/api/workflows/wf-1/memories/tables"));
+    expect(await listRes.json()).toEqual(["new-table"]);
+  });
+
+  it("is idempotent: creating the same table twice returns 200 both times", async () => {
+    await insertWorkflow("wf-1");
+
+    const first = await app.request(
+      jsonRequest("POST", "/api/workflows/wf-1/memories/tables", { name: "dup-table" }),
+    );
+    expect(first.status).toBe(200);
+
+    const second = await app.request(
+      jsonRequest("POST", "/api/workflows/wf-1/memories/tables", { name: "dup-table" }),
+    );
+    expect(second.status).toBe(200);
+    expect((await second.json()).name).toBe("dup-table");
+
+    const listRes = await app.request(jsonRequest("GET", "/api/workflows/wf-1/memories/tables"));
+    expect(await listRes.json()).toEqual(["dup-table"]);
+  });
+
+  it("trims whitespace from the name", async () => {
+    await insertWorkflow("wf-1");
+
+    const res = await app.request(
+      jsonRequest("POST", "/api/workflows/wf-1/memories/tables", { name: "  spaced  " }),
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).name).toBe("spaced");
+  });
+
+  it("rejects an empty name", async () => {
+    await insertWorkflow("wf-1");
+
+    const res = await app.request(
+      jsonRequest("POST", "/api/workflows/wf-1/memories/tables", { name: "   " }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a name longer than 64 characters", async () => {
+    await insertWorkflow("wf-1");
+
+    const res = await app.request(
+      jsonRequest("POST", "/api/workflows/wf-1/memories/tables", { name: "a".repeat(65) }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a request missing name", async () => {
+    await insertWorkflow("wf-1");
+
+    const res = await app.request(
+      jsonRequest("POST", "/api/workflows/wf-1/memories/tables", {}),
+    );
+    expect(res.status).toBe(400);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════
@@ -348,6 +476,33 @@ describe("DELETE /:workflowId/memories", () => {
     const remaining = await listRes.json();
     expect(remaining).toHaveLength(1);
     expect(remaining[0].tableName).toBe("table-b");
+  });
+
+  it("also removes the table's registry entry when deleting scoped to that table", async () => {
+    await insertWorkflow("wf-1");
+    await insertMemory("wf-1", "table-a", "a1");
+    await insertMemoryTable("wf-1", "table-a");
+    await insertMemoryTable("wf-1", "table-b"); // untouched registry entry
+
+    const res = await app.request(
+      jsonRequest("DELETE", "/api/workflows/wf-1/memories?table_name=table-a"),
+    );
+    expect(res.status).toBe(200);
+
+    const tablesRes = await app.request(jsonRequest("GET", "/api/workflows/wf-1/memories/tables"));
+    expect(await tablesRes.json()).toEqual(["table-b"]);
+  });
+
+  it("removes all registry entries for the workflow when deleting all memories", async () => {
+    await insertWorkflow("wf-1");
+    await insertMemoryTable("wf-1", "table-a");
+    await insertMemoryTable("wf-1", "table-b");
+
+    const res = await app.request(jsonRequest("DELETE", "/api/workflows/wf-1/memories"));
+    expect(res.status).toBe(200);
+
+    const tablesRes = await app.request(jsonRequest("GET", "/api/workflows/wf-1/memories/tables"));
+    expect(await tablesRes.json()).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## 概要

v2.7.0 予定の記憶システム（memory-save / memory-search / MemoryViewer）に対する実機検証後のUX改善2点。

### 1. テーブル名のセレクター化＋テーブル追加

自由入力だった `tableName` 設定をタイプミスによるテーブル分裂から守るため、セレクターに変更。

- **DB**: `memory_tables` レジストリテーブルを新設（`workflow_id`, `name` の複合ユニークインデックス）。空のテーブルも事前登録できる。
- **API**:
  - `GET /:workflowId/memories/tables` を「レジストリ ∪ memories の distinct table_name」の和集合に変更（重複除去・ソート済み）
  - `POST /:workflowId/memories/tables` を新設。`{ name }`（trim後 1〜64文字、Zod検証）。既存なら200でそのまま返す（冪等）。workflow不存在は404。
  - `DELETE /:workflowId/memories` でメモリー本体に加えてレジストリのエントリも削除（`table_name` 指定時はそのテーブルのみ、未指定時はワークフロー全体）
  - リポジトリ層（`db/memories-repository.ts`）に対応関数を追加し、ルートは薄く維持
- **ノード設定UI**: manifest に新フィールド型 `"memory-table"` を追加。
  - `configUtils.ts` の `mapFieldType()` と `types.ts` の型定義に追加
  - `NodeSettings.tsx` に `MemoryTableField` コンポーネントを実装。現在の workflowId で `api.listMemoryTables()` を取得したセレクト＋「＋ 新しいテーブルを作成」を選ぶとインライン入力欄→確定で `POST tables` →作成したテーブルを選択状態にする
  - **既存ワークフローの後方互換**: 現在の設定値がリストに無い場合も選択肢として表示（`options = value && !tables.includes(value) ? [value, ...tables] : tables`）
  - `CustomNode.tsx` のインライン表示では、他の複雑フィールド（prompt-builder等）と同様に `COMPLEX_FIELD_TYPES` に加え、設定パネルへの導線（Open in Settings）にフォールバック
  - `api.ts` に `createMemoryTable()` を追加
- **MemoryViewer**: テーブルフィルタの横に「＋」ボタンを追加。同じ `POST` でテーブルを作成→一覧を自動リフレッシュ→作成したテーブルを選択状態にする
- **manifest更新**: `plugins/memory-save/manifest.json` と `plugins/memory-search/manifest.json` の `tableName` を `"type": "memory-table"` に変更（node.ts側は無変更、値は従来どおり文字列で config に保存されるため後方互換）
- i18n: `apps/web/locales/ja.json` / `en.json` の `settings.*` / `memories.*` に日英ラベルを追加

### 2. memory-search の検索タイプ連動の動的表示

- 既存の `showWhen` 機構（`configUtils.ts` の `evaluateShowWhen` / `NodeSettings.tsx` と `CustomNode.tsx` の両方で参照）が既にフィールド単位のフィルタリングをサポート済みだったため、追加実装は不要でした。
- `plugins/memory-search/manifest.json` の `defaultQuery` に `"showWhen": { "key": "searchType", "value": "keyword" }` を追加。`defaultLimit` は両タイプで表示のまま。
- **値の保持**: `NodeSettings.tsx` の `handleChange` / `CustomNode.tsx` の `onInlineConfigChange` はいずれも `{ ...config, [key]: value }` で config オブジェクトをマージするのみで、非表示フィールドの値を削除するロジックが元々存在しないため、`searchType` を切り替えても `defaultQuery` の値は消えない。Playwright での手動確認で実際に動作を確認済み（後述）。

## 逸脱

- 設計書では「showWhen が configUtils/NodeSettings の manifest 駆動経路でサポートされているか確認し、未対応なら最小限の対応を追加」とあったが、確認の結果すでにフル対応済みだったため、manifest への `showWhen` 追加のみで完了。

## テスト・検証

- `tests/routes/memories.test.ts` に追記:
  - `GET /:workflowId/memories/tables` が レジストリ∪使用中テーブルの和集合を返す（重複除去・ワークフロー間の非リーク含む）
  - `POST /:workflowId/memories/tables` の作成・冪等性・trim・空文字/65文字超のバリデーション・404
  - `DELETE /:workflowId/memories` （全体削除・テーブル指定削除）でレジストリのエントリも削除されること
- `npm test` (bun test): **342 pass / 0 fail**
- `apps/web` で `npx tsc --noEmit`: エラーなし
- `npm run lint`: 変更ファイルに新規エラーなし（`eslint` 上は既存の warning のみ、`server-ts` 側の biome format 差分は今回変更していない既存ファイル群にも及ぶ pre-existing の CRLF 起因の環境差分で本PRの変更によるものではない）
- **実機確認（PORT=8005 バックエンド / PORT=3005 フロント、`NEXT_PUBLIC_API_URL` 経由で接続）**: Playwright でワークフローを作成し、Memory Search ノードを配置して以下を確認
  - テーブル名セレクターに `default`（未登録の現在値でも選択肢に出る後方互換）が表示される
  - 「＋ 新しいテーブルを作成」からインライン入力→作成→自動選択まで動作
  - `searchType` を `keyword` に切り替えると `defaultQuery` フィールドが設定パネル・インライン表示の両方に出現
  - `defaultQuery` に値を入力後、`recent` に戻すとフィールドが隠れ、再度 `keyword` に戻すと入力値がそのまま復元される（値保持を確認）
  - MemoryViewer の「＋」ボタンからもテーブル作成→一覧リフレッシュを確認
  - なお `apps/web/lib/runtimeEndpoints.ts` の `getApiBaseUrl()`/`getWsBaseUrl()` は開発ポート（3000-3010）を `localhost:8001` に固定しているため、手動確認中のみ一時的に `8005` へ書き換えて検証し、確認後に元に戻してからコミットしている（差分には含まれない）

## テスト計画

- [x] `npm test` 全pass
- [x] `apps/web` `npx tsc --noEmit` エラーなし
- [x] `npm run lint` 新規エラーなし
- [x] Playwright での手動確認（テーブルセレクター・動的表示・値保持・MemoryViewerのテーブル追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)