### PR TITLE
サイドバーのノード表示改善: 左寄せ修正とアイコン刷新(lucide-react/simple-icons)

### DIFF
--- a/apps/web/components/editor/Sidebar.tsx
+++ b/apps/web/components/editor/Sidebar.tsx
@@ -344,7 +344,7 @@ export default function Sidebar({ isRunning, onToggleRun, onSave, onExport, onIm
                           draggable
                           onDragStart={(e) => handleDragStart(e, plugin)}
                           onClick={() => handleClick(plugin)}
-                          className="p-2 rounded cursor-grab active:cursor-grabbing flex items-center gap-1.5 text-xs text-fg transition-all hover:opacity-80 hover:scale-105"
+                          className="p-2 rounded cursor-grab active:cursor-grabbing flex items-center gap-1.5 text-xs text-left text-fg transition-all hover:opacity-80 hover:scale-105"
                           style={{
                             background: bgColor,
                             border: `1px solid ${color}40`,

--- a/apps/web/lib/icons.tsx
+++ b/apps/web/lib/icons.tsx
@@ -1,191 +1,169 @@
 import React from 'react';
+import {
+  // Control flow
+  Play,
+  Square,
+  RefreshCw,
+  List,
+  GitBranch,
+  Clock,
+  Hourglass,
+  Move,
+  CalendarClock,
+  // Input / text
+  Type,
+  CaseSensitive,
+  // LLM
+  Cpu,
+  Zap,
+  // TTS / audio
+  Volume2,
+  AudioLines,
+  AudioWaveform,
+  Radio,
+  Mic2,
+  Speaker,
+  // Avatar
+  User,
+  Smile,
+  Mic,
+  // Output
+  Terminal,
+  Subtitles,
+  Gift,
+  // Utility
+  Variable,
+  Globe,
+  Dice5,
+  FileJson,
+  Database,
+  Search,
+  FileText,
+  // Fallback
+  Box,
+  type LucideProps,
+} from 'lucide-react';
+import {
+  siAnthropic,
+  siGooglegemini,
+  siMistralai,
+  siOllama,
+  siDiscord,
+  siTwitch,
+  siYoutube,
+  siObsstudio,
+  type SimpleIcon,
+} from 'simple-icons';
 
-// Icon component props
+// Icon component props (kept stable — consumed by Sidebar.tsx and CustomNode.tsx)
 interface IconProps {
   size?: number;
   color?: string;
   className?: string;
 }
 
-// SVG icon components mapped from Lucide icon names
-const icons: Record<string, React.FC<IconProps>> = {
-  // Control Flow
-  Play: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8" fill={color}/>
-    </svg>
-  ),
-  Square: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <circle cx="12" cy="12" r="10"/><rect x="9" y="9" width="6" height="6" fill={color}/>
-    </svg>
-  ),
-  RefreshCw: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/>
-      <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>
-    </svg>
-  ),
-  List: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/>
-      <line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/>
-    </svg>
-  ),
-  GitBranch: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <polyline points="16 3 21 3 21 8"/><line x1="4" y1="20" x2="21" y2="3"/>
-      <polyline points="21 16 21 21 16 21"/><line x1="15" y1="15" x2="21" y2="21"/>
-      <line x1="4" y1="4" x2="9" y2="9"/>
-    </svg>
-  ),
-  Clock: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
-    </svg>
-  ),
-
-  // Input
-  Type: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <polyline points="4 7 4 4 20 4 20 7"/><line x1="9" y1="20" x2="15" y2="20"/>
-      <line x1="12" y1="4" x2="12" y2="20"/>
-    </svg>
-  ),
-  MessageSquare: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
-    </svg>
-  ),
-
-  // LLM
-  Cpu: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/>
-      <line x1="9" y1="1" x2="9" y2="4"/><line x1="15" y1="1" x2="15" y2="4"/>
-      <line x1="9" y1="20" x2="9" y2="23"/><line x1="15" y1="20" x2="15" y2="23"/>
-      <line x1="20" y1="9" x2="23" y2="9"/><line x1="20" y1="14" x2="23" y2="14"/>
-      <line x1="1" y1="9" x2="4" y2="9"/><line x1="1" y1="14" x2="4" y2="14"/>
-    </svg>
-  ),
-
-  // TTS
-  Volume2: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
-      <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
-      <path d="M15.54 8.46a5 5 0 0 1 0 7.07"/>
-    </svg>
-  ),
-
-  // Avatar
-  User: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <circle cx="12" cy="8" r="4"/>
-      <path d="M4 20v-2a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v2"/>
-    </svg>
-  ),
-  Smile: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <circle cx="12" cy="12" r="10"/>
-      <path d="M8 14s1.5 2 4 2 4-2 4-2"/>
-      <line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/>
-    </svg>
-  ),
-  Mic: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <path d="M12 18c-4 0-6-2-6-2s2-2 6-2 6 2 6 2-2 2-6 2z"/>
-      <circle cx="12" cy="12" r="10"/>
-    </svg>
-  ),
-
-  // Output
-  Terminal: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
-    </svg>
-  ),
-  Subtitles: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <rect x="2" y="6" width="20" height="12" rx="2"/>
-      <line x1="6" y1="12" x2="18" y2="12"/>
-      <line x1="6" y1="15" x2="14" y2="15"/>
-    </svg>
-  ),
-  Gift: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <polyline points="20 12 20 22 4 22 4 12"/>
-      <rect x="2" y="7" width="20" height="5"/>
-      <line x1="12" y1="22" x2="12" y2="7"/>
-      <path d="M12 7H7.5a2.5 2.5 0 0 1 0-5C11 2 12 7 12 7z"/>
-      <path d="M12 7h4.5a2.5 2.5 0 0 0 0-5C13 2 12 7 12 7z"/>
-    </svg>
-  ),
-
-  // Utility
-  Variable: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <path d="M4 7h6M14 7h6M8 17h8"/>
-      <path d="M7 3l-4 4 4 4M17 13l4 4-4 4"/>
-    </svg>
-  ),
-  Globe: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/>
-      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
-    </svg>
-  ),
-  Dice5: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <rect x="3" y="3" width="18" height="18" rx="2"/>
-      <circle cx="8" cy="8" r="1.5" fill={color}/><circle cx="16" cy="16" r="1.5" fill={color}/>
-      <circle cx="12" cy="12" r="1.5" fill={color}/>
-    </svg>
-  ),
-  FileJson: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-      <polyline points="14 2 14 8 20 8"/>
-      <path d="M10 12a1 1 0 0 0-1 1v1a1 1 0 0 1-1 1 1 1 0 0 1 1 1v1a1 1 0 0 0 1 1"/>
-      <path d="M14 18a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1 1 1 0 0 1-1-1v-1a1 1 0 0 0-1-1"/>
-    </svg>
-  ),
-
-  // OBS
-  Monitor: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <rect x="2" y="3" width="20" height="14" rx="2"/>
-      <line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/>
-    </svg>
-  ),
-  Eye: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
-      <circle cx="12" cy="12" r="3"/>
-    </svg>
-  ),
-
-  // Default
-  Box: ({ size = 14, color = 'currentColor', className }) => (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" className={className}>
-      <rect x="3" y="3" width="18" height="18" rx="2"/>
-    </svg>
-  ),
+/**
+ * lucide-react icons, imported individually (named imports) so unused icons are tree-shaken
+ * out of the production bundle. Add new entries here as plugins adopt new icon names —
+ * only icons actually referenced by a plugin's manifest.json `ui.icon` should be listed.
+ */
+const lucideIcons: Record<string, React.ComponentType<LucideProps>> = {
+  Play,
+  Square,
+  RefreshCw,
+  List,
+  GitBranch,
+  Clock,
+  Hourglass,
+  Move,
+  CalendarClock,
+  Type,
+  CaseSensitive,
+  Cpu,
+  Zap,
+  Volume2,
+  AudioLines,
+  AudioWaveform,
+  Radio,
+  Mic2,
+  Speaker,
+  User,
+  Smile,
+  Mic,
+  Terminal,
+  Subtitles,
+  Gift,
+  Variable,
+  Globe,
+  Dice5,
+  FileJson,
+  Database,
+  Search,
+  FileText,
+  Box,
 };
 
 /**
- * Get an icon component by Lucide icon name
+ * simple-icons brand icons, imported individually (named imports) and referenced via the
+ * "si:<slug>" convention in a plugin's `ui.icon` (e.g. "si:anthropic"). simple-icons paths are
+ * monochrome silhouettes meant to be filled with a single color, so these are rendered with
+ * `fill`, unlike the stroke-based lucide icons above.
  */
-export function getIconComponent(iconName: string): React.FC<IconProps> {
-  return icons[iconName] ?? icons.Box;
+const simpleIcons: Record<string, SimpleIcon> = {
+  anthropic: siAnthropic,
+  googlegemini: siGooglegemini,
+  mistralai: siMistralai,
+  ollama: siOllama,
+  discord: siDiscord,
+  twitch: siTwitch,
+  youtube: siYoutube,
+  obsstudio: siObsstudio,
+};
+
+function SimpleIconSvg({
+  icon,
+  size = 14,
+  color = 'currentColor',
+  className,
+}: IconProps & { icon: SimpleIcon }): React.ReactElement {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      className={className}
+      role="img"
+      aria-label={icon.title}
+    >
+      <path d={icon.path} fill={color} />
+    </svg>
+  );
 }
 
 /**
- * Render an icon by name
+ * Get an icon component by name.
+ * - "si:<slug>" resolves against simple-icons brand icons (e.g. "si:anthropic").
+ * - Anything else resolves against the lucide-react icon map above.
+ * - Falls back to the generic `Box` icon if the name isn't found.
+ */
+export function getIconComponent(iconName: string): React.FC<IconProps> {
+  if (iconName?.startsWith('si:')) {
+    const slug = iconName.slice(3);
+    const icon = simpleIcons[slug];
+    if (icon) {
+      return (props: IconProps) => <SimpleIconSvg icon={icon} {...props} />;
+    }
+    return lucideIcons.Box as unknown as React.FC<IconProps>;
+  }
+  return (lucideIcons[iconName] ?? lucideIcons.Box) as unknown as React.FC<IconProps>;
+}
+
+/**
+ * Render an icon by name.
  */
 export function renderIcon(iconName: string, props: IconProps = {}): React.ReactNode {
   const IconComponent = getIconComponent(iconName);
   return <IconComponent {...props} />;
 }
 
-export default icons;
+export default lucideIcons;

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -14,9 +14,11 @@
         "@tauri-apps/plugin-updater": "^2.10.0",
         "@types/three": "^0.182.0",
         "@xyflow/react": "^12.0.0",
+        "lucide-react": "^1.23.0",
         "next": "^16.2.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "simple-icons": "^16.25.0",
         "three": "^0.182.0",
         "uuid": "^14.0.0",
         "zustand": "^4.5.0"
@@ -5111,6 +5113,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.23.0.tgz",
+      "integrity": "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6255,6 +6266,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-icons": {
+      "version": "16.25.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.25.0.tgz",
+      "integrity": "sha512-ReYPfbqjkTBovxjerHw2tf6E1rQdaCqNJKaJbd78Mui8w+78xQlE1aDO/2ekID++n8qa+1t+oaueYLeiSoQsIA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/simple-icons"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/simple-icons"
+        }
+      ],
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=0.12.18"
       }
     },
     "node_modules/source-map-js": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,9 +16,11 @@
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@types/three": "^0.182.0",
     "@xyflow/react": "^12.0.0",
+    "lucide-react": "^1.23.0",
     "next": "^16.2.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "simple-icons": "^16.25.0",
     "three": "^0.182.0",
     "uuid": "^14.0.0",
     "zustand": "^4.5.0"

--- a/plugins/aivis-tts/manifest.json
+++ b/plugins/aivis-tts/manifest.json
@@ -12,7 +12,7 @@
   "category": "tts",
   "ui": {
     "label": "AivisSpeech",
-    "icon": "Volume2",
+    "icon": "AudioWaveform",
     "color": "#8B5CF6",
     "bgColor": "rgba(139, 92, 246, 0.1)",
     "statusText": "Engine: AivisSpeech"

--- a/plugins/anthropic-llm/manifest.json
+++ b/plugins/anthropic-llm/manifest.json
@@ -12,9 +12,9 @@
   "category": "llm",
   "ui": {
     "label": "Claude",
-    "icon": "Cpu",
-    "color": "#D97706",
-    "bgColor": "rgba(217, 119, 6, 0.1)",
+    "icon": "si:anthropic",
+    "color": "#191919",
+    "bgColor": "rgba(25, 25, 25, 0.1)",
     "statusText": "Model: Claude"
   },
   "node": {

--- a/plugins/anthropic-llm/manifest.json
+++ b/plugins/anthropic-llm/manifest.json
@@ -13,8 +13,8 @@
   "ui": {
     "label": "Claude",
     "icon": "si:anthropic",
-    "color": "#191919",
-    "bgColor": "rgba(25, 25, 25, 0.1)",
+    "color": "#D97757",
+    "bgColor": "rgba(217, 119, 87, 0.1)",
     "statusText": "Model: Claude"
   },
   "node": {

--- a/plugins/coeiroink-tts/manifest.json
+++ b/plugins/coeiroink-tts/manifest.json
@@ -12,7 +12,7 @@
   "category": "tts",
   "ui": {
     "label": "COEIROINK",
-    "icon": "Volume2",
+    "icon": "Radio",
     "color": "#E91E63",
     "bgColor": "rgba(233, 30, 99, 0.1)",
     "statusText": "Engine: COEIROINK"

--- a/plugins/delay/manifest.json
+++ b/plugins/delay/manifest.json
@@ -12,7 +12,7 @@
   "category": "control",
   "ui": {
     "label": "Delay",
-    "icon": "Clock",
+    "icon": "Hourglass",
     "color": "#F97316",
     "bgColor": "rgba(249, 115, 22, 0.1)",
     "statusText": "Delay: 1000ms"

--- a/plugins/discord-chat/manifest.json
+++ b/plugins/discord-chat/manifest.json
@@ -12,7 +12,7 @@
   "category": "input",
   "ui": {
     "label": "Discord Chat",
-    "icon": "MessageSquare",
+    "icon": "si:discord",
     "color": "#5865F2",
     "bgColor": "rgba(88, 101, 242, 0.1)",
     "statusText": "Waiting for messages..."

--- a/plugins/google-llm/manifest.json
+++ b/plugins/google-llm/manifest.json
@@ -12,9 +12,9 @@
   "category": "llm",
   "ui": {
     "label": "Gemini",
-    "icon": "Cpu",
-    "color": "#4285F4",
-    "bgColor": "rgba(66, 133, 244, 0.1)",
+    "icon": "si:googlegemini",
+    "color": "#8E75B2",
+    "bgColor": "rgba(142, 117, 178, 0.1)",
     "statusText": "Model: Gemini"
   },
   "node": {

--- a/plugins/mistral-llm/manifest.json
+++ b/plugins/mistral-llm/manifest.json
@@ -12,9 +12,9 @@
   "category": "llm",
   "ui": {
     "label": "Mistral",
-    "icon": "Wind",
-    "color": "#FF7000",
-    "bgColor": "rgba(255, 112, 0, 0.1)",
+    "icon": "si:mistralai",
+    "color": "#FA520F",
+    "bgColor": "rgba(250, 82, 15, 0.1)",
     "statusText": "Mistral AI"
   },
   "node": {

--- a/plugins/motion-trigger/manifest.json
+++ b/plugins/motion-trigger/manifest.json
@@ -12,7 +12,7 @@
   "category": "avatar",
   "ui": {
     "label": "Motion Trigger",
-    "icon": "Play",
+    "icon": "Move",
     "color": "#C084FC",
     "bgColor": "rgba(192, 132, 252, 0.1)",
     "statusText": "Motion Trigger"

--- a/plugins/obs-scene-switch/manifest.json
+++ b/plugins/obs-scene-switch/manifest.json
@@ -12,9 +12,9 @@
   "category": "obs",
   "ui": {
     "label": "OBS Scene Switch",
-    "icon": "Monitor",
-    "color": "#8B7CC4",
-    "bgColor": "rgba(139, 124, 196, 0.15)",
+    "icon": "si:obsstudio",
+    "color": "#302E31",
+    "bgColor": "rgba(48, 46, 49, 0.15)",
     "statusText": "OBS Scene Switch"
   },
   "node": {

--- a/plugins/obs-scene-switch/manifest.json
+++ b/plugins/obs-scene-switch/manifest.json
@@ -13,8 +13,8 @@
   "ui": {
     "label": "OBS Scene Switch",
     "icon": "si:obsstudio",
-    "color": "#302E31",
-    "bgColor": "rgba(48, 46, 49, 0.15)",
+    "color": "#8B7CC4",
+    "bgColor": "rgba(139, 124, 196, 0.15)",
     "statusText": "OBS Scene Switch"
   },
   "node": {

--- a/plugins/obs-source-toggle/manifest.json
+++ b/plugins/obs-source-toggle/manifest.json
@@ -12,9 +12,9 @@
   "category": "obs",
   "ui": {
     "label": "OBS Source Toggle",
-    "icon": "Eye",
-    "color": "#8B7CC4",
-    "bgColor": "rgba(139, 124, 196, 0.15)",
+    "icon": "si:obsstudio",
+    "color": "#302E31",
+    "bgColor": "rgba(48, 46, 49, 0.15)",
     "statusText": "OBS Source Toggle"
   },
   "node": {

--- a/plugins/obs-source-toggle/manifest.json
+++ b/plugins/obs-source-toggle/manifest.json
@@ -13,8 +13,8 @@
   "ui": {
     "label": "OBS Source Toggle",
     "icon": "si:obsstudio",
-    "color": "#302E31",
-    "bgColor": "rgba(48, 46, 49, 0.15)",
+    "color": "#8B7CC4",
+    "bgColor": "rgba(139, 124, 196, 0.15)",
     "statusText": "OBS Source Toggle"
   },
   "node": {

--- a/plugins/ollama-llm/manifest.json
+++ b/plugins/ollama-llm/manifest.json
@@ -13,8 +13,8 @@
   "ui": {
     "label": "Ollama",
     "icon": "si:ollama",
-    "color": "#000000",
-    "bgColor": "rgba(0, 0, 0, 0.15)",
+    "color": "#5E81AC",
+    "bgColor": "rgba(94, 129, 172, 0.15)",
     "statusText": "Model: Ollama"
   },
   "node": {

--- a/plugins/ollama-llm/manifest.json
+++ b/plugins/ollama-llm/manifest.json
@@ -12,9 +12,9 @@
   "category": "llm",
   "ui": {
     "label": "Ollama",
-    "icon": "Cpu",
-    "color": "#5E81AC",
-    "bgColor": "rgba(94, 129, 172, 0.15)",
+    "icon": "si:ollama",
+    "color": "#000000",
+    "bgColor": "rgba(0, 0, 0, 0.15)",
     "statusText": "Model: Ollama"
   },
   "node": {

--- a/plugins/sbv2-tts/manifest.json
+++ b/plugins/sbv2-tts/manifest.json
@@ -12,7 +12,7 @@
   "category": "tts",
   "ui": {
     "label": "Style-Bert-VITS2",
-    "icon": "Volume2",
+    "icon": "Mic2",
     "color": "#9C27B0",
     "bgColor": "rgba(156, 39, 176, 0.1)",
     "statusText": "Engine: Style-Bert-VITS2"

--- a/plugins/text-transform/manifest.json
+++ b/plugins/text-transform/manifest.json
@@ -12,7 +12,7 @@
   "category": "utility",
   "ui": {
     "label": "Text Transform",
-    "icon": "Type",
+    "icon": "CaseSensitive",
     "color": "#EC4899",
     "bgColor": "rgba(236, 72, 153, 0.1)",
     "statusText": "Text Transform"

--- a/plugins/twitch-chat/manifest.json
+++ b/plugins/twitch-chat/manifest.json
@@ -12,7 +12,7 @@
   "category": "input",
   "ui": {
     "label": "Twitch Chat",
-    "icon": "MessageSquare",
+    "icon": "si:twitch",
     "color": "#9146FF",
     "bgColor": "rgba(145, 70, 255, 0.1)",
     "statusText": "Waiting for chat..."

--- a/plugins/voicevox-tts/manifest.json
+++ b/plugins/voicevox-tts/manifest.json
@@ -12,7 +12,7 @@
   "category": "tts",
   "ui": {
     "label": "VOICEVOX",
-    "icon": "Volume2",
+    "icon": "Speaker",
     "color": "#F59E0B",
     "bgColor": "rgba(245, 158, 11, 0.1)",
     "statusText": "Engine: VOICEVOX"

--- a/plugins/youtube-chat/manifest.json
+++ b/plugins/youtube-chat/manifest.json
@@ -12,7 +12,7 @@
   "category": "input",
   "ui": {
     "label": "YouTube Chat",
-    "icon": "MessageSquare",
+    "icon": "si:youtube",
     "color": "#FF0000",
     "bgColor": "rgba(255, 0, 0, 0.1)",
     "statusText": "Waiting for comments..."


### PR DESCRIPTION
## 概要

- **サイドバーの左寄せ修正**: ノード一覧の各プラグインボタンにラベルが2行に折り返すと中央寄せに見える不具合を修正
- **アイコン表示の全面刷新**: 手書きSVG約24種の自前実装（`Box`へのサイレントフォールバックあり）を廃止し、`lucide-react` / `simple-icons` の実アイコンに置き換え。あわせて重複・破損していたアイコン割り当てを39プラグイン中16件で再設計

## 1. サイドバーの左寄せ修正

- `apps/web/components/editor/Sidebar.tsx:347` — ノード一覧グリッドの各プラグインボタンの className に `text-left` を追加
  - 原因: `<button>` はブラウザのデフォルトスタイルで `text-align: center` になり、Tailwind Preflight もこれを上書きしない。1行に収まるラベルは flex box が内容にシュリンクするため見た目上問題が出ないが、長いラベルが2行に折り返すと2行目が1行目の幅を基準に中央寄せされ、「短いノードは左寄せ、長いノードは中央寄せ」に見える不整合が発生していた
  - 同じファイルのカテゴリヘッダーボタン（`Sidebar.tsx:312`）はもともと `text-left` を持っており左寄せで正しかったため、そのスタイルに合わせた
- 監査した他のボタン/ラベル表示箇所（変更不要と判断）:
  - `apps/web/components/editor/ContextMenu.tsx:74,159` — 既に `text-left` 指定済みで、ラベルも `truncate`（単一行）のため問題なし
  - `apps/web/components/editor/CustomNode.tsx:1616,1568` — ノードヘッダーのラベルは `truncate` で単一行固定のため折り返し自体が発生しない
  - `apps/web/components/editor/SearchPanel.tsx` — アイコンのみのボタンでテキストラベルなし、対象外
  - `apps/web/components/panels/ActivityDrawer.tsx` / `NodeSettings.tsx` — `usePluginStore` はラベル文字列の参照のみで、プラグイン一覧をボタングリッドとして描画していないため対象外
- 意図的に変更していないもの: `Sidebar.tsx` の "Loading plugins..." / "No nodes found" 等の空状態メッセージ（`text-center` は意図した用途）、`MotionLibrary.tsx` / `ExpressionPresets.tsx` などの別グリッドピッカー（スコープ外）

## 2. アイコン表示の全面刷新

### アーキテクチャ変更（`apps/web/lib/icons.tsx`）

- 手書きSVGコンポーネント（~24種）を全て削除し、`lucide-react`（named importで個別インポート、tree-shaking対応）に置き換え
- `"si:<slug>"` 形式（例: `si:anthropic`）のアイコン名は `simple-icons` のブランドアイコンとして解決。simple-iconsのパスは単色シルエットのため `fill` でレンダリング（lucideはstroke方式のまま維持し、レンダラー内で分岐）
- `getIconComponent(name)` / `renderIcon(name, props)` / デフォルトエクスポートの呼び出し規約（`IconProps` = `size`/`color`/`className`）は変更なし。呼び出し元（`Sidebar.tsx`, `CustomNode.tsx`）の修正は不要
- 見つからない名前は従来通り `Box`（lucide-react）にフォールバック
- `lucide-react@^1.23.0`（React 18.3.1と互換）、`simple-icons@^16.25.0` を `apps/web/package.json` に追加。どちらも個別 named import のみを使用しており、`import * as` は一切していない（バンドルサイズ懸念への対応）

### 副次的に修正されたバグ

旧・手書きSVGマップに存在せず `Box`（無地の四角）に見えていたアイコンは、実体を持つ lucide-react アイコンとして自動的に正しく表示されるようになった:
`CalendarClock`（cron-trigger）, `Zap`（groq-llm）, `AudioLines`（openai-tts）※

※ いずれも今回のマニフェスト変更なし（値はそのまま）で自動的に直る

### 最終アイコン割り当て表（全39プラグイン）

| プラグイン | 最終 ui.icon | 種別 | 理由 |
|---|---|---|---|
| aivis-tts | `AudioWaveform` | lucide | Volume2の5重複を解消。TTSエンジンごとに区別できる波形系アイコン。AivisSpeechはsimple-iconsに無いため商標を模倣せずlucideの汎用アイコンで代替（色は既存の#8B5CF6を維持、確証のない公式色の推測はしていない） |
| anthropic-llm | `si:anthropic` | si: | Cpuの4重複を解消。公式ブランドロゴが simple-icons に実在するため採用。色は公式hex #191919 がダークテーマで不可視のため、Claudeのテラコッタ系アクセント `#D97757` を採用（後述の「近黒ブランドカラーの扱い」参照） |
| audio-player | `Volume2`（変更なし） | lucide | 汎用の音声再生ノード。TTSエンジン群とは役割が異なる正当な汎用アイコンとして維持（意図的な残存、後述） |
| avatar-configuration | `User`（変更なし） | lucide | 重複なし、意味的に妥当 |
| coeiroink-tts | `Radio` | lucide | Volume2の5重複を解消。COEIROINKはsimple-iconsに無いためlucideの汎用アイコンで代替（色は既存の#E91E63を維持） |
| console-output | `Terminal`（変更なし） | lucide | 重複なし |
| cron-trigger | `CalendarClock`（値は変更なし） | lucide | 旧手書きマップに無く常にBoxに見えていたが、実体を持つlucideアイコンとして自動修正 |
| data-formatter | `FileJson`（変更なし） | lucide | 重複なし |
| delay | `Hourglass` | lucide | Clockの2重複を解消（timerと区別）。「待機」を表す典型的アイコン |
| discord-chat | `si:discord` | si: | MessageSquareの3重複を解消。公式ブランドロゴ採用。色は既存の`#5865F2`が既に公式hexと一致していたため変更なし |
| donation-alert | `Gift`（変更なし） | lucide | 重複なし |
| emotion-analyzer | `Smile`（変更なし） | lucide | 重複なし |
| end | `Square`（変更なし） | lucide | 重複なし、「停止」の標準的な表現 |
| foreach | `List`（変更なし） | lucide | 重複なし |
| google-llm | `si:googlegemini` | si: | Cpuの4重複を解消。Google全般ではなく製品としてのGeminiロゴを採用。色も公式hex `#8E75B2` に更新（既存の汎用Googleブルーから変更、両テーマで可読） |
| groq-llm | `Zap`（値は変更なし） | lucide | simple-iconsにGroqのロゴが存在しないことを確認済み。旧手書きマップには無くBoxに見えていたが実体を持つlucideアイコンとして自動修正。色は既存の#F55036を維持 |
| http-request | `Globe`（変更なし） | lucide | 重複なし |
| lip-sync | `Mic`（変更なし） | lucide | 重複なし。sbv2-ttsのMic2とは別アイコンで区別 |
| loop | `RefreshCw`（変更なし） | lucide | 重複なし |
| manual-input | `Type`（変更なし） | lucide | Typeの2重複はtext-transform側を変更して解消。手動入力=「入力」の意味で最も適合するため据え置き |
| memory-save | `Database`（manifest未変更） | lucide | 他エージェント編集中のためmanifestは触っていない。新レンダラーの lucide マップに `Database` を追加済みで正しく描画される |
| memory-search | `Search`（manifest未変更） | lucide | 同上。`Search` をマップに追加済み |
| mistral-llm | `si:mistralai` | si: | Cpuの4重複を解消（Windは旧手書きマップにもなく実質破損状態だった）。公式ブランドロゴ採用。色も公式hex `#FA520F` に更新（既存の#FF7000から補正） |
| motion-trigger | `Move` | lucide | Playの2重複を解消（startと区別）。アバターの動作トリガーを表す意味的に妥当なアイコン |
| obs-scene-switch | `si:obsstudio` | si: | 公式ブランドロゴ採用。色は公式hex #302E31 が近黒でダークテーマ不可視のため、既存の `#8B7CC4` を維持 |
| obs-source-toggle | `si:obsstudio` | si: | 同上。obs-scene-switchと**意図的に同一アイコン**（後述の「意図的な重複」参照） |
| ollama-llm | `si:ollama` | si: | Cpuの4重複を解消。公式ブランドロゴ採用。Ollamaのブランドは黒/白のみで使えるアクセント色がないため、色は既存の `#5E81AC` を維持 |
| openai-llm | `Cpu`（値は変更なし） | lucide | simple-iconsにOpenAIのロゴが存在しないことを確認済み（`siOpenai`等のエクスポートなし）。他3件のLLMプロバイダーがsi:へ移行した結果、Cpuを使うのはopenai-llmのみとなり自然に重複が解消された。色は既存の#10B981（OpenAIのいわゆる"ChatGPT green"に近い一般的に知られた配色）を維持 |
| openai-tts | `AudioLines`（値は変更なし） | lucide | 旧手書きマップに無くBoxに見えていたが実体を持つlucideアイコンとして自動修正。色は既存の#10B981を維持 |
| prompt-builder | `FileText`（manifest未変更） | lucide | 他エージェント編集中のためmanifestは触っていない。`FileText` をマップに追加済み |
| random | `Dice5`（変更なし） | lucide | 重複なし |
| sbv2-tts | `Mic2` | lucide | Volume2の5重複を解消。Style-Bert-VITS2は音声「スタイル」制御が特徴のためMic系アイコンで区別。simple-iconsに無いため商標を模倣せずlucideで代替（色は既存の#9C27B0を維持） |
| start | `Play`（変更なし） | lucide | Playの2重複はmotion-trigger側を変更して解消。ワークフロー開始=「再生」の意味で最も適合するため据え置き |
| subtitle-display | `Subtitles`（変更なし） | lucide | 重複なし |
| switch | `GitBranch`（変更なし） | lucide | 重複なし、分岐制御として妥当 |
| text-transform | `CaseSensitive` | lucide | Typeの2重複を解消（manual-inputと区別）。文字列変換（大文字/小文字等）を表す意味的に妥当なアイコン |
| timer | `Clock`（変更なし） | lucide | Clockの2重複はdelay側を変更して解消。「時計」の意味で最も適合するため据え置き |
| twitch-chat | `si:twitch` | si: | MessageSquareの3重複を解消。公式ブランドロゴ採用。色は既存の`#9146FF`が既に公式hexと一致していたため変更なし |
| variable | `Variable`（変更なし） | lucide | 重複なし |
| voicevox-tts | `Speaker` | lucide | Volume2の5重複を解消。VOICEVOXはsimple-iconsに無いためlucideの汎用アイコンで代替（色は既存の#F59E0Bを維持） |
| youtube-chat | `si:youtube` | si: | MessageSquareの3重複を解消。公式ブランドロゴ採用。色は既存の`#FF0000`が既に公式hexと一致していたため変更なし |

### 商標・著作権に関する判断

- **simple-icons に実在を確認できたブランド**（`node_modules/simple-icons` の named export を直接確認して採用）: Anthropic, Google Gemini, Mistral AI, Ollama, Discord, Twitch, YouTube, OBS Studio。いずれも公式hexを併せて設定
- **simple-icons に存在しないことを確認したブランド**（推測でスラッグを書かず、実際に `require('simple-icons')` のexportを検索して不在を確認）:
  - **OpenAI**（openai-llm, openai-tts）: `siOpenai` は存在しない（`siOpenaigym` のみヒット、別物）。ロゴを自作・模写することはせず、既存の `Cpu` / `AudioLines`（lucideの汎用アイコン）と既存の色設定をそのまま維持
  - **Groq**（groq-llm）: `siGroq` は存在しない。既存の `Zap`（lucide）と既存の色設定を維持
  - **VOICEVOX / COEIROINK / AivisSpeech / Style-Bert-VITS2**（voicevox-tts, coeiroink-tts, aivis-tts, sbv2-tts）: いずれもsimple-iconsに無い。日本語音声合成エンジンでロゴの著作権も不明瞭なため、模写・自作は行わず、エンジンごとに異なるlucideの音声/波形系アイコン（`Speaker` / `Radio` / `AudioWaveform` / `Mic2`）で視覚的に区別する方針を採用。テキストモノグラム（"V"/"C"等）は検討したが、既存のUIパターン（アイコン+単色チップ）との一貫性を優先し、確実に存在確認できるlucideアイコンでの区別を選んだ
  - 上記いずれも「確証のないブランド色を捏造しない」方針に基づき、色（`ui.color`/`ui.bgColor`）は既存値をそのまま維持（変更していない）

### 近黒ブランドカラーの扱い（ダークテーマ対応）

キャンバス上のノードヘッダーは `legibleAccent()`（`apps/web/components/editor/CustomNode.tsx`）で暗いアクセント色から保護されているが、**サイドバーは `ui.color` を生のまま**アイコンfill・枠線（`${color}40`）・背景色に使う。そのため simple-icons の公式hexが近黒のブランドはダークテーマのサイドバーでほぼ不可視になる。ブランドの識別は si: シルエット（ロゴ形状）が担うので、`ui.color` はテーマセーフなアクセントに寄せる判断をした:

- **anthropic-llm**: 公式hex #191919 → `#D97757`（Claudeのテラコッタ系アクセント。両テーマで可読かつブランド連想が効く）
- **ollama-llm**: 公式hex #000000 → 既存色 `#5E81AC` に復帰(Ollamaは黒/白のみでアクセント色が存在しない）
- **obs-scene-switch / obs-source-toggle**: 公式hex #302E31 → 既存色 `#8B7CC4` に復帰（同上）
- Gemini `#8E75B2` / Mistral `#FA520F` は両テーマで可読なため公式hexのまま

### 意図的に残した重複

- `obs-scene-switch` と `obs-source-toggle` はどちらも `si:obsstudio` を使用。同一ソフトウェア（OBS Studio）の異なる操作を表すノードであり、他に区別できる公式サブブランドロゴが存在しないための意図的な選択（見落としではない）
- `audio-player` の `Volume2` は、TTSエンジン群（voicevox-tts等）とは異なる「汎用オーディオ再生」ノードとして意図的に維持
- プログラムでの重複チェック（全マニフェストの `ui.icon` をグループ化するスクリプト）を実施し、上記2件（実質1組）以外の意図しない重複が無いことを確認済み

## テスト結果

- `cd apps/web && npx tsc --noEmit` → **エラーなし**
- `npm run lint`（ルート） → web側は既存の警告のみ（変更ファイルである `icons.tsx` / `Sidebar.tsx` は0件）。server-ts側の biome エラーは今回のPRで一切変更していない `apps/server-ts/src/engine/executor.ts` 等の既存 `noExplicitAny` warningで、dev ブランチに既存の状態（server-tsは1ファイルも触っていない）
- `npm test`（ルート） → **331 pass / 0 fail**（bun:test、tests/ 配下19ファイル）
- `cd apps/web && npm run build`（Next.js production build, Turbopack） → **成功**（simple-icons / lucide-react のバンドラー解決に問題なし）
- 重複アイコンの自動検証スクリプト（全マニフェストの `ui.icon` をグループ化）→ 意図的な1件（obs系）以外の重複なしを確認

## 手動確認手順（ライブスクリーンショット検証は未実施）

ポート競合回避の制約上、既存の3000/8001を使う開発サーバーとは別ポートでの起動確認までは実施していません。動作確認する場合の手順:

```
cd apps/server-ts && PORT=8006 bun run dev
cd apps/web && PORT=3006 npm run dev
```
（`apps/web/lib/runtimeEndpoints.ts` を確認し、必要ならバックエンドURLをクエリパラメータ等で8006に向ける）

1. `http://localhost:3006/editor/<workflow-id>` を開く
2. 左サイドバーでLLM/TTS/チャット系カテゴリを展開し、Claude/Gemini/Mistral/Ollama/Discord/Twitch/YouTube/OBS系ノードがブランドロゴで表示されることを確認
3. ラベルが2行に折り返す長いノード名（例: "Style-Bert-VITS2"）が常に左寄せになっていることを確認
4. ライト/ダークテーマを切り替え、アイコンの視認性（特に `si:ollama`/`si:obsstudio` の黒系カラー）を確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
