### PR TITLE
fix: WebSocket ハンドシェイクに Origin 検証を追加

### DIFF
--- a/apps/server-ts/src/index.ts
+++ b/apps/server-ts/src/index.ts
@@ -16,6 +16,7 @@ import { templateRoutes } from "./routes/templates";
 import { setExecutor, setWSBroadcaster, workflowRoutes } from "./routes/workflows";
 import { shutdownGracefully } from "./shutdown";
 import { createWebSocketHandler, setExecutorForWS, wsBroadcaster } from "./websocket/handler";
+import { buildAllowedWsOrigins, createWsOriginGuard } from "./websocket/origin-check";
 
 const app = new Hono();
 // biome-ignore lint/suspicious/noExplicitAny: Bun ServerWebSocket requires any as data type parameter
@@ -23,6 +24,9 @@ const { upgradeWebSocket, websocket } = createBunWebSocket<ServerWebSocket<any>>
 
 // Static file serving directory (set by Tauri for desktop mode)
 const STATIC_DIR = process.env.STATIC_DIR;
+
+const parsedPort = process.env.PORT === undefined ? Number.NaN : Number(process.env.PORT);
+const port = Number.isFinite(parsedPort) ? parsedPort : 8001;
 
 // CORS configuration
 const corsOrigins = process.env.CORS_ORIGINS
@@ -61,9 +65,13 @@ app.route("/api/integrations", integrationRoutes);
 app.route("/api/settings", settingsRoutes);
 
 // WebSocket endpoint
+// CORS does not apply to WebSocket handshakes, so validate Origin explicitly:
+// without this, any web page could connect to ws://127.0.0.1:8001/ws.
 const wsHandler = createWebSocketHandler();
+const allowedWsOrigins = buildAllowedWsOrigins(corsOrigins, port);
 app.get(
   "/ws",
+  createWsOriginGuard(allowedWsOrigins),
   upgradeWebSocket(() => wsHandler),
 );
 
@@ -113,8 +121,6 @@ if (STATIC_DIR) {
 // Initialize database on startup
 initDb();
 
-const parsedPort = process.env.PORT === undefined ? Number.NaN : Number(process.env.PORT);
-const port = Number.isFinite(parsedPort) ? parsedPort : 8001;
 // Default to localhost-only binding for security: without an explicit hostname,
 // Bun binds to 0.0.0.0 (all network interfaces), exposing unauthenticated REST/WS
 // routes to anyone on the same LAN. Set HOST=0.0.0.0 to restore LAN-wide access

--- a/apps/server-ts/src/websocket/origin-check.ts
+++ b/apps/server-ts/src/websocket/origin-check.ts
@@ -1,0 +1,55 @@
+/**
+ * WebSocket Origin validation.
+ *
+ * Browsers attach an Origin header to WebSocket handshakes, but CORS does
+ * NOT apply to WebSocket connections — without an explicit check, JavaScript
+ * on any web page the user visits can open ws://127.0.0.1:8001/ws and send
+ * commands such as workflow_stop. This module rejects handshakes whose
+ * Origin is present but not in the allowlist.
+ *
+ * Requests without an Origin header (native clients, CLI tools, health
+ * probes) are allowed: this check defends against browser-mediated
+ * cross-site connections, not local processes, which can connect regardless.
+ */
+
+import type { Context, Next } from "hono";
+
+/**
+ * Build the WS origin allowlist from the HTTP CORS allowlist plus the
+ * server's own origin (desktop mode serves the UI from the sidecar itself).
+ */
+export function buildAllowedWsOrigins(corsOrigins: string[], port: number): Set<string> {
+  const origins = new Set<string>();
+  for (const origin of corsOrigins) {
+    origins.add(origin.toLowerCase());
+  }
+  origins.add(`http://localhost:${port}`);
+  origins.add(`http://127.0.0.1:${port}`);
+  // Tauri WebView origins (kept for safety even though the desktop app
+  // currently loads the UI over http://localhost — see PR #280).
+  origins.add("tauri://localhost");
+  origins.add("https://tauri.localhost");
+  return origins;
+}
+
+/**
+ * True when the handshake may proceed: no Origin header, or an Origin
+ * present in the allowlist. `Origin: null` (file:// pages, sandboxed
+ * iframes) is rejected.
+ */
+export function isAllowedWsOrigin(origin: string | undefined, allowed: Set<string>): boolean {
+  if (origin === undefined) return true;
+  return allowed.has(origin.toLowerCase());
+}
+
+/** Hono middleware rejecting WS upgrade requests from disallowed origins. */
+export function createWsOriginGuard(allowed: Set<string>) {
+  return async (c: Context, next: Next) => {
+    const origin = c.req.header("origin");
+    if (!isAllowedWsOrigin(origin, allowed)) {
+      console.warn(`[ws] rejected WebSocket handshake from disallowed origin: ${origin}`);
+      return c.text("Forbidden: origin not allowed", 403);
+    }
+    await next();
+  };
+}

--- a/tests/routes/ws-origin.test.ts
+++ b/tests/routes/ws-origin.test.ts
@@ -1,0 +1,91 @@
+/**
+ * WebSocket Origin validation - Tests
+ *
+ * CORS does not apply to WebSocket handshakes, so the server validates the
+ * Origin header explicitly before upgrading. These tests cover the
+ * allowlist construction, the predicate, and the Hono middleware guard
+ * (via `app.request()`, no running server needed).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import {
+  buildAllowedWsOrigins,
+  createWsOriginGuard,
+  isAllowedWsOrigin,
+} from "../../apps/server-ts/src/websocket/origin-check";
+
+const CORS_ORIGINS = ["http://localhost:3000", "http://127.0.0.1:3000"];
+
+describe("buildAllowedWsOrigins", () => {
+  it("includes CORS origins, the server's own origin, and Tauri origins", () => {
+    const allowed = buildAllowedWsOrigins(CORS_ORIGINS, 8001);
+    expect(allowed.has("http://localhost:3000")).toBe(true);
+    expect(allowed.has("http://127.0.0.1:3000")).toBe(true);
+    expect(allowed.has("http://localhost:8001")).toBe(true);
+    expect(allowed.has("http://127.0.0.1:8001")).toBe(true);
+    expect(allowed.has("tauri://localhost")).toBe(true);
+    expect(allowed.has("https://tauri.localhost")).toBe(true);
+  });
+
+  it("normalizes CORS origins to lowercase", () => {
+    const allowed = buildAllowedWsOrigins(["http://LocalHost:3000"], 8001);
+    expect(allowed.has("http://localhost:3000")).toBe(true);
+  });
+});
+
+describe("isAllowedWsOrigin", () => {
+  const allowed = buildAllowedWsOrigins(CORS_ORIGINS, 8001);
+
+  it("allows requests without an Origin header (native clients)", () => {
+    expect(isAllowedWsOrigin(undefined, allowed)).toBe(true);
+  });
+
+  it("allows allowlisted origins regardless of case", () => {
+    expect(isAllowedWsOrigin("http://localhost:3000", allowed)).toBe(true);
+    expect(isAllowedWsOrigin("HTTP://LOCALHOST:3000", allowed)).toBe(true);
+  });
+
+  it("rejects cross-site origins", () => {
+    expect(isAllowedWsOrigin("https://evil.example.com", allowed)).toBe(false);
+  });
+
+  it("rejects Origin: null (file:// pages, sandboxed iframes)", () => {
+    expect(isAllowedWsOrigin("null", allowed)).toBe(false);
+  });
+
+  it("rejects lookalike origins (prefix/suffix tricks)", () => {
+    expect(isAllowedWsOrigin("http://localhost:3000.evil.example.com", allowed)).toBe(false);
+    expect(isAllowedWsOrigin("http://evil-localhost:3000", allowed)).toBe(false);
+  });
+});
+
+describe("createWsOriginGuard middleware", () => {
+  function buildApp(): Hono {
+    const app = new Hono();
+    const allowed = buildAllowedWsOrigins(CORS_ORIGINS, 8001);
+    app.get("/ws", createWsOriginGuard(allowed), (c) => c.text("upgraded"));
+    return app;
+  }
+
+  it("passes through requests without an Origin header", async () => {
+    const res = await buildApp().request("/ws");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("upgraded");
+  });
+
+  it("passes through requests from allowlisted origins", async () => {
+    const res = await buildApp().request("/ws", {
+      headers: { origin: "http://localhost:3000" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects requests from disallowed origins with 403", async () => {
+    const res = await buildApp().request("/ws", {
+      headers: { origin: "https://evil.example.com" },
+    });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain("origin not allowed");
+  });
+});


### PR DESCRIPTION
## 概要

2026-07 レビューバックログのセキュリティ項目「WS ハンドシェイクに Origin 検証・認証なし」への対応です。

CORS は WebSocket のハンドシェイクに適用されないため、ユーザーが開いた任意の Web ページの JavaScript から `ws://127.0.0.1:8001/ws` に接続でき、`workflow_stop` などのコマンドを送信できる問題がありました。

- `apps/server-ts/src/websocket/origin-check.ts` を新設し、`/ws` のアップグレード前に Hono ミドルウェアで Origin を検証
- 許可リスト = HTTP の CORS 許可リスト（`CORS_ORIGINS` env / デフォルト localhost:3000〜3010）＋サーバー自身のオリジン（デスクトップモードはサイドカー自身が UI を配信するため）＋ Tauri WebView オリジン
- Origin ヘッダーが許可リスト外 → **403 Forbidden**（アップグレードせず拒否）
- Origin ヘッダーなし（非ブラウザのネイティブクライアント）→ 従来通り許可（この検証はブラウザ経由のクロスサイト接続対策であり、ローカルプロセスは元々接続可能なため）
- `Origin: null`（file:// ページ・sandboxed iframe）→ 拒否

## テスト計画

- [x] ユニットテスト追加 `tests/routes/ws-origin.test.ts`（許可リスト構築・判定・ミドルウェアの 403/通過）— 341 件全パス
- [x] `tsc --noEmit` / Biome（LF 展開で確認、CRLF 偽エラー除外）
- [x] 実サーバーで検証: `Origin: https://evil.example.com` → 403、許可オリジン・Origin なし・自オリジン → 101 Switching Protocols
- [x] フロントエンド（localhost:3000）・デスクトップモード（自オリジン配信）の接続経路は許可リストでカバー

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfvdGygZGLkMLvhQr1L6qp