### PR TITLE
fix: discord-chat/twitch-chat の受信ハンドラの未処理 Promise を解消

### DIFF
--- a/plugins/discord-chat/node.ts
+++ b/plugins/discord-chat/node.ts
@@ -70,14 +70,23 @@ export default class DiscordChatNode extends InputNode {
       ],
     });
 
-    // Set up event handlers
+    // Set up event handlers.
+    // discord.js listeners are synchronous: an async callback that rejects
+    // becomes an unhandled rejection and can bring down the whole Bun
+    // process, so every promise created here must catch its own errors.
     this.client.on("ready", () => {
       this.running = true;
-      context.log(`Discord bot connected as ${this.client!.user?.tag}`);
+      context
+        .log(`Discord bot connected as ${this.client!.user?.tag}`)
+        .catch(() => {});
     });
 
     this.client.on("messageCreate", (message: DiscordMessage) => {
-      this.handleMessage(message, context);
+      this.handleMessage(message, context).catch((e) => {
+        context
+          .log(`Failed to handle Discord message: ${String(e)}`, "error")
+          .catch(() => {});
+      });
     });
 
     // Start bot in background

--- a/plugins/twitch-chat/node.ts
+++ b/plugins/twitch-chat/node.ts
@@ -85,18 +85,27 @@ export default class TwitchChatNode extends InputNode {
         self: boolean,
       ) => {
         if (self) return;
-        this.handleMessage(channel, userstate, message, context);
+        // tmi.js listeners are synchronous: a rejected promise here becomes
+        // an unhandled rejection and can bring down the whole Bun process,
+        // so every promise created in these handlers must catch its own errors.
+        this.handleMessage(channel, userstate, message, context).catch((e) => {
+          context
+            .log(`Failed to handle Twitch message: ${String(e)}`, "error")
+            .catch(() => {});
+        });
       },
     );
 
     this.tmiClient.on("connected", () => {
       this.connected = true;
-      context.log(`Connected to Twitch chat: #${this.channel}`);
+      context.log(`Connected to Twitch chat: #${this.channel}`).catch(() => {});
     });
 
     this.tmiClient.on("disconnected", (reason: string) => {
       this.connected = false;
-      context.log(`Disconnected from Twitch: ${reason}`, "warning");
+      context
+        .log(`Disconnected from Twitch: ${reason}`, "warning")
+        .catch(() => {});
     });
 
     // connect() never settles while tmi.js is in its reconnect-retry loop


### PR DESCRIPTION
## 概要

2026-07 レビューバックログのエラー処理項目「discord-chat/twitch-chat の受信ハンドラが浮いた Promise」への対応です。

discord.js / tmi.js のイベントリスナーは同期呼び出しのため、リスナー内で async の `handleMessage()` を catch なしで呼ぶと、`emitEvent` 等の失敗が未処理 rejection となり、最悪 Bun プロセスごと落ちるリスクがありました。

- `handleMessage()` 呼び出しに `.catch()` を付け、失敗はノードの error ログとしてフロントに通知
- `ready` / `connected` / `disconnected` ハンドラ内で浮いていた `context.log()` の Promise も `.catch(() => {})` で解消（ログ通知自体の失敗でプロセスを落とさない）

## テスト計画

- [x] 両プラグインの動的 import でロード確認（Bun で transpile が通ること）
- [x] `bun test tests/` 331 件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfvdGygZGLkMLvhQr1L6qp