### PR TITLE
feat: 起動時のポート自動切り替えと画面下部通知を追加

### DIFF
--- a/apps/server-ts/src/index.ts
+++ b/apps/server-ts/src/index.ts
@@ -8,6 +8,7 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { initDb } from "./db/database";
 import { WorkflowExecutor } from "./engine/executor";
+import { healthPayload, resolvePort } from "./port";
 import { integrationRoutes } from "./routes/integrations";
 import { memoryRoutes } from "./routes/memories";
 import { pluginRoutes } from "./routes/plugins";
@@ -49,8 +50,35 @@ setExecutor(executor);
 setWSBroadcaster(wsBroadcaster);
 setExecutorForWS(executor);
 
-// Health check
-app.get("/health", (c) => c.json({ status: "healthy", version: "2.0.0", runtime: "bun" }));
+// Resolve the bind port BEFORE any handler that reports it (e.g. /health) so
+// the whole app closes over a single, settled port value.
+//
+// - Explicit PORT (e.g. desktop mode / PORT=9000): use it as-is, no auto-switch.
+// - Otherwise: scan 8001..8010 for the first free port so `bun run dev` no
+//   longer fails when 8001 is already in use.
+//
+// Default to localhost-only binding for security: without an explicit hostname,
+// Bun binds to 0.0.0.0 (all network interfaces), exposing unauthenticated
+// REST/WS routes to anyone on the same LAN. Set HOST=0.0.0.0 to restore
+// LAN-wide access (e.g. when OBS or the browser overlay runs on another machine).
+const hostname = process.env.HOST || "127.0.0.1";
+const resolved = resolvePort({
+  portEnv: process.env.PORT,
+  // Reused across --hot reloads within the same process so the port stays put.
+  reusePort: process.env.AITUBERFLOW_RESOLVED_PORT,
+  hostname,
+});
+const port = resolved.port;
+// Persist the chosen port so --hot reloads reuse it instead of re-scanning.
+process.env.AITUBERFLOW_RESOLVED_PORT = String(port);
+if (resolved.switched && !resolved.explicit) {
+  console.log(
+    `[port] Default port ${resolved.defaultPort} was in use; started on port ${port} instead`,
+  );
+}
+
+// Health check (reports the actual port + default so the frontend can detect a switch)
+app.get("/health", (c) => c.json(healthPayload(port, resolved.defaultPort)));
 
 // API routes (must be registered BEFORE static file serving)
 app.route("/api/workflows", workflowRoutes);
@@ -113,13 +141,6 @@ if (STATIC_DIR) {
 // Initialize database on startup
 initDb();
 
-const parsedPort = process.env.PORT === undefined ? Number.NaN : Number(process.env.PORT);
-const port = Number.isFinite(parsedPort) ? parsedPort : 8001;
-// Default to localhost-only binding for security: without an explicit hostname,
-// Bun binds to 0.0.0.0 (all network interfaces), exposing unauthenticated REST/WS
-// routes to anyone on the same LAN. Set HOST=0.0.0.0 to restore LAN-wide access
-// (e.g. when OBS or the browser overlay runs on a different machine).
-const hostname = process.env.HOST || "127.0.0.1";
 console.log(`Started development server: http://${hostname}:${port}`);
 
 // Graceful shutdown handler

--- a/apps/server-ts/src/port.ts
+++ b/apps/server-ts/src/port.ts
@@ -1,0 +1,114 @@
+/**
+ * Port resolution for the development / web-mode server.
+ *
+ * In desktop mode the Tauri host assigns a dynamic port and passes it via the
+ * PORT env var, so there is never a conflict. In web mode (`bun run dev`) the
+ * server binds a fixed default port and previously failed hard when it was
+ * already taken. These helpers let the server fall back to the next free port
+ * in a small range when PORT is not explicitly set.
+ */
+
+export const DEFAULT_PORT = 8001;
+export const MAX_PORT = 8010;
+
+/** A function that attempts to bind a port and returns whether it succeeded. */
+export type PortProbe = (port: number, hostname: string) => boolean;
+
+/**
+ * Real port probe using Bun.serve: try to bind, immediately stop on success.
+ *
+ * Bun.serve throws synchronously with `code === "EADDRINUSE"` when the port is
+ * taken (verified against Bun 1.3.x). Any other error is re-thrown so genuine
+ * problems (e.g. permission denied) are not silently swallowed.
+ */
+export const bunPortProbe: PortProbe = (port, hostname) => {
+  try {
+    const probe = Bun.serve({ port, hostname, fetch: () => new Response(null) });
+    probe.stop(true);
+    return true;
+  } catch (err) {
+    if ((err as { code?: string }).code === "EADDRINUSE") return false;
+    throw err;
+  }
+};
+
+/**
+ * Find the first bindable port in [start, end] (inclusive), scanning upward.
+ * Throws if none are available. `probe` is injectable for testing.
+ */
+export function findAvailablePort(
+  start: number,
+  end: number,
+  hostname: string,
+  probe: PortProbe = bunPortProbe,
+): number {
+  for (let p = start; p <= end; p++) {
+    if (probe(p, hostname)) return p;
+  }
+  throw new Error(`No available port found in range ${start}-${end}`);
+}
+
+export interface ResolvedPort {
+  /** The port the server will actually bind. */
+  port: number;
+  /** The default port (8001); lets clients detect that a switch happened. */
+  defaultPort: number;
+  /** True when the server ended up on a non-default port. */
+  switched: boolean;
+  /** True when the port came from an explicit PORT env var (no auto-switch). */
+  explicit: boolean;
+}
+
+/**
+ * Decide which port to bind.
+ *
+ * - Explicit `PORT` (non-empty): use it verbatim, never auto-switch. A bind
+ *   failure later surfaces as a normal error, matching prior behavior.
+ * - `reusePort` (set on `--hot` reloads via env) is reused so the port stays
+ *   stable across hot reloads within the same process.
+ * - Otherwise scan DEFAULT_PORT..MAX_PORT for the first free port.
+ */
+export function resolvePort(options: {
+  portEnv?: string;
+  reusePort?: string;
+  hostname: string;
+  probe?: PortProbe;
+  start?: number;
+  end?: number;
+}): ResolvedPort {
+  const { portEnv, reusePort, hostname, probe = bunPortProbe } = options;
+  const start = options.start ?? DEFAULT_PORT;
+  const end = options.end ?? MAX_PORT;
+
+  if (portEnv !== undefined && portEnv.trim() !== "") {
+    const parsed = Number(portEnv);
+    const port = Number.isFinite(parsed) ? parsed : DEFAULT_PORT;
+    return { port, defaultPort: DEFAULT_PORT, switched: port !== DEFAULT_PORT, explicit: true };
+  }
+
+  if (reusePort !== undefined && reusePort.trim() !== "") {
+    const parsed = Number(reusePort);
+    if (Number.isFinite(parsed)) {
+      return {
+        port: parsed,
+        defaultPort: DEFAULT_PORT,
+        switched: parsed !== DEFAULT_PORT,
+        explicit: false,
+      };
+    }
+  }
+
+  const port = findAvailablePort(start, end, hostname, probe);
+  return { port, defaultPort: DEFAULT_PORT, switched: port !== DEFAULT_PORT, explicit: false };
+}
+
+/** Build the /health JSON payload including the resolved port information. */
+export function healthPayload(port: number, defaultPort: number = DEFAULT_PORT) {
+  return {
+    status: "healthy",
+    version: "2.0.0",
+    runtime: "bun",
+    port,
+    defaultPort,
+  } as const;
+}

--- a/apps/web/app/(editor)/editor/[id]/client-page.tsx
+++ b/apps/web/app/(editor)/editor/[id]/client-page.tsx
@@ -21,8 +21,6 @@ import { DEFAULT_MODEL_URL } from '@/lib/constants';
 import { resolveWorkflowId } from '@/lib/routeParams';
 import { getApiBaseUrl } from '@/lib/runtimeEndpoints';
 
-const API_BASE = getApiBaseUrl();
-
 // Auto-save error throttling state (module-level to persist across re-renders)
 let lastAutoSaveError: string | null = null;
 let lastAutoSaveErrorAt: number = 0;
@@ -81,7 +79,7 @@ const getFullUrl = (url: string | undefined): string | undefined => {
   }
   // API path - prepend backend URL
   if (url.startsWith('/api/')) {
-    return `${API_BASE}${url}`;
+    return `${getApiBaseUrl()}${url}`;
   }
   return url;
 };

--- a/apps/web/app/(editor)/preview/[id]/client-page.tsx
+++ b/apps/web/app/(editor)/preview/[id]/client-page.tsx
@@ -7,12 +7,9 @@ import api, { ModelInfo } from '@/lib/api';
 import { Workflow } from '@/lib/types';
 import { DEFAULT_MODEL_URL } from '@/lib/constants';
 import { resolveWorkflowId } from '@/lib/routeParams';
-import { getApiBaseUrl, getWsBaseUrl } from '@/lib/runtimeEndpoints';
+import { getApiBaseUrl, getWsBaseUrl, ensureDevPortResolved } from '@/lib/runtimeEndpoints';
 import { useTranslation } from '@/stores/localeStore';
 import { toast } from '@/stores/toastStore';
-
-const WS_URL = getWsBaseUrl();
-const API_BASE = getApiBaseUrl();
 
 // Helper to get full URL (backend serves uploaded files)
 const getFullUrl = (url: string | undefined): string | undefined => {
@@ -23,7 +20,7 @@ const getFullUrl = (url: string | undefined): string | undefined => {
   }
   // If it's an API path, prepend the API base
   if (url.startsWith('/api/')) {
-    return `${API_BASE}${url}`;
+    return `${getApiBaseUrl()}${url}`;
   }
   return url;
 };
@@ -134,10 +131,19 @@ export default function PreviewPage() {
   useEffect(() => {
     if (!workflowId || workflowId === '_') return;
 
-    const wsUrl = `${WS_URL.replace(/^http/, 'ws')}/ws`;
-    const ws = new WebSocket(wsUrl);
-    wsRef.current = ws;
+    let cancelled = false;
+    let ws: WebSocket | null = null;
 
+    // Resolve the (possibly auto-switched) backend port before connecting.
+    ensureDevPortResolved().then(() => {
+      if (cancelled) return;
+      const wsUrl = `${getWsBaseUrl().replace(/^http/, 'ws')}/ws`;
+      ws = new WebSocket(wsUrl);
+      wsRef.current = ws;
+      attachHandlers(ws);
+    });
+
+    function attachHandlers(ws: WebSocket) {
     ws.onopen = () => {
       console.log('Connected to WebSocket');
       setConnected(true);
@@ -175,7 +181,7 @@ export default function PreviewPage() {
             break;
           case 'audio':
             if (rest.filename) {
-              const audioUrl = `${API_BASE}/api/integrations/audio/${rest.filename}`;
+              const audioUrl = `${getApiBaseUrl()}/api/integrations/audio/${rest.filename}`;
               console.log('Playing audio:', audioUrl);
               if (audioRef.current) {
                 audioRef.current.pause();
@@ -198,12 +204,16 @@ export default function PreviewPage() {
         console.warn('Failed to parse WebSocket message:', err);
       }
     };
+    }
 
     return () => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'leave', payload: { workflowId } }));
+      cancelled = true;
+      if (ws) {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'leave', payload: { workflowId } }));
+        }
+        ws.close();
       }
-      ws.close();
       wsRef.current = null;
       if (audioRef.current) {
         audioRef.current.pause();

--- a/apps/web/app/(overlay)/overlay/[id]/client-page.tsx
+++ b/apps/web/app/(overlay)/overlay/[id]/client-page.tsx
@@ -39,11 +39,8 @@ import { useSearchParams, useParams } from 'next/navigation';
 import { AvatarView, AvatarState, RendererType } from '@/components/avatar';
 import api from '@/lib/api';
 import { resolveWorkflowId } from '@/lib/routeParams';
-import { getApiBaseUrl, getWsBaseUrl } from '@/lib/runtimeEndpoints';
+import { getApiBaseUrl, getWsBaseUrl, ensureDevPortResolved } from '@/lib/runtimeEndpoints';
 import { ReconnectingWebSocket } from '@/lib/reconnectingWebSocket';
-
-const WS_URL = getWsBaseUrl();
-const API_BASE = getApiBaseUrl();
 
 const getFullUrl = (url: string | undefined): string | undefined => {
   if (!url) return undefined;
@@ -51,7 +48,7 @@ const getFullUrl = (url: string | undefined): string | undefined => {
     return url;
   }
   if (url.startsWith('/api/')) {
-    return `${API_BASE}${url}`;
+    return `${getApiBaseUrl()}${url}`;
   }
   return url;
 };
@@ -190,12 +187,18 @@ export default function OverlayPage() {
   useEffect(() => {
     if (!workflowId || workflowId === '_') return;
 
-    const wsUrl = `${WS_URL.replace(/^http/, 'ws')}/ws`;
+    let cancelled = false;
+    let rws: ReconnectingWebSocket | null = null;
+
+    // Resolve the (possibly auto-switched) backend port before connecting.
+    ensureDevPortResolved().then(() => {
+      if (cancelled) return;
+      const wsUrl = `${getWsBaseUrl().replace(/^http/, 'ws')}/ws`;
 
     // OBS Browser Sources run unattended (no one to hit "reload"), so the
     // overlay must keep retrying forever on disconnect rather than giving
     // up after a fixed number of attempts.
-    const rws = new ReconnectingWebSocket({
+    const socket: ReconnectingWebSocket = new ReconnectingWebSocket({
       url: wsUrl,
       maxReconnectAttempts: Infinity,
       onStatusChange: (status) => {
@@ -210,7 +213,7 @@ export default function OverlayPage() {
       },
       onOpen: () => {
         console.log('[Overlay] Connected');
-        rws.send(JSON.stringify({ type: 'join', payload: { workflowId } }));
+        socket.send(JSON.stringify({ type: 'join', payload: { workflowId } }));
       },
       onMessage: (event) => {
         try {
@@ -301,7 +304,7 @@ export default function OverlayPage() {
               if (!rest.filename) break;
               const audioUrl = rest.filename.startsWith('http')
                 ? rest.filename
-                : `${API_BASE}/api/integrations/audio/${rest.filename}`;
+                : `${getApiBaseUrl()}/api/integrations/audio/${rest.filename}`;
 
               if (audioRef.current) {
                 audioRef.current.pause();
@@ -323,7 +326,7 @@ export default function OverlayPage() {
               if (!rest.filename) break;
               const playUrl = rest.filename.startsWith('http')
                 ? rest.filename
-                : `${API_BASE}/api/integrations/audio/${rest.filename}`;
+                : `${getApiBaseUrl()}/api/integrations/audio/${rest.filename}`;
 
               if (audioRef.current) {
                 audioRef.current.pause();
@@ -357,7 +360,7 @@ export default function OverlayPage() {
               if (alertData.sound) {
                 const soundUrl = alertData.sound.startsWith('http')
                   ? alertData.sound
-                  : `${API_BASE}${alertData.sound}`;
+                  : `${getApiBaseUrl()}${alertData.sound}`;
 
                 if (donationAudioRef.current) {
                   donationAudioRef.current.pause();
@@ -397,11 +400,16 @@ export default function OverlayPage() {
       },
     });
 
-    rws.connect();
+      rws = socket;
+      socket.connect();
+    });
 
     return () => {
-      rws.send(JSON.stringify({ type: 'leave', payload: { workflowId } }));
-      rws.close();
+      cancelled = true;
+      if (rws) {
+        rws.send(JSON.stringify({ type: 'leave', payload: { workflowId } }));
+        rws.close();
+      }
       if (subtitleTimerRef.current) clearTimeout(subtitleTimerRef.current);
       if (subtitleFadeTimerRef.current) clearTimeout(subtitleFadeTimerRef.current);
       if (donationTimerRef.current) clearTimeout(donationTimerRef.current);

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import ToastContainer from '@/components/ui/ToastContainer';
+import PortSwitchNotice from '@/components/ui/PortSwitchNotice';
 
 /**
  * Root Layout
@@ -29,6 +30,7 @@ export default function RootLayout({
       <body suppressHydrationWarning>
         {children}
         <ToastContainer />
+        <PortSwitchNotice />
       </body>
     </html>
   );

--- a/apps/web/components/ui/PortSwitchNotice.tsx
+++ b/apps/web/components/ui/PortSwitchNotice.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { ensureDevPortResolved } from '@/lib/runtimeEndpoints';
+import { useTranslation } from '@/stores/localeStore';
+
+const DISMISS_KEY = 'aituber-flow-port-notice-dismissed';
+
+/**
+ * Bottom-fixed notice shown when the backend auto-switched off its default
+ * port (8001). Dev-mode only: `ensureDevPortResolved()` resolves immediately
+ * with `switched: false` in production/desktop, so this renders nothing there.
+ *
+ * Styling mirrors AnnouncementBanner's `info` palette (theme-aware tokens,
+ * text + color only, no icons). Dismissal is remembered for the session only.
+ */
+export default function PortSwitchNotice() {
+  const { t } = useTranslation();
+  const [port, setPort] = useState<number | null>(null);
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    ensureDevPortResolved().then((info) => {
+      if (!active) return;
+      if (info.switched) {
+        setPort(info.port);
+        try {
+          setDismissed(sessionStorage.getItem(DISMISS_KEY) === '1');
+        } catch {
+          setDismissed(false);
+        }
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (port === null || dismissed) return null;
+
+  const message = t('portNotice.message').replace('{port}', String(port));
+
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-[min(92vw,32rem)] px-2">
+      <div
+        className="bg-blue-100 dark:bg-blue-900/40 border border-blue-300 dark:border-blue-500/50
+          rounded-lg px-4 py-3 flex items-start gap-3 shadow-lg"
+      >
+        <p className="flex-1 min-w-0 text-sm text-blue-800 dark:text-blue-300">{message}</p>
+        <button
+          onClick={() => {
+            setDismissed(true);
+            try {
+              sessionStorage.setItem(DISMISS_KEY, '1');
+            } catch {
+              // ignore
+            }
+          }}
+          aria-label={t('common.close')}
+          className="flex-shrink-0 w-6 h-6 rounded flex items-center justify-center
+            text-fg-faint hover:text-fg hover:bg-hover transition-colors"
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/hooks/useWebSocket.ts
+++ b/apps/web/hooks/useWebSocket.ts
@@ -1,10 +1,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { useWorkflowStore } from '@/stores/workflowStore';
 import { AvatarState } from '@/components/avatar';
-import { getApiBaseUrl, getWsBaseUrl } from '@/lib/runtimeEndpoints';
-
-const WS_URL = getWsBaseUrl();
-const API_URL = getApiBaseUrl();
+import { getApiBaseUrl, getWsBaseUrl, ensureDevPortResolved } from '@/lib/runtimeEndpoints';
 
 // Reconnection settings with exponential backoff
 const INITIAL_RECONNECT_DELAY = 1000; // 1 second
@@ -50,8 +47,8 @@ export function useWebSocket(workflowId: string | null) {
     let intentionalClose = false;
 
     function getWsUrl(): string {
-      // Convert http(s):// to ws(s)://
-      const base = WS_URL.replace(/^http/, 'ws');
+      // Read the (possibly auto-switched) port lazily at connect time.
+      const base = getWsBaseUrl().replace(/^http/, 'ws');
       return `${base}/ws`;
     }
 
@@ -233,7 +230,7 @@ export function useWebSocket(workflowId: string | null) {
 
         case 'audio':
           if (rest.filename) {
-            const audioUrl = `${API_URL}/api/integrations/audio/${rest.filename}`;
+            const audioUrl = `${getApiBaseUrl()}/api/integrations/audio/${rest.filename}`;
             addLog({
               level: 'info',
               message: `${audioRef.current ? 'Queued' : 'Playing'} audio: ${rest.text?.substring(0, 30) || 'audio'}...`,
@@ -272,7 +269,11 @@ export function useWebSocket(workflowId: string | null) {
       }
     }
 
-    connect();
+    // Ensure the backend port is resolved before the first connection so we
+    // don't attempt ws://localhost:8001 when the server auto-switched ports.
+    ensureDevPortResolved().then(() => {
+      if (!intentionalClose) connect();
+    });
 
     return () => {
       intentionalClose = true;

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,24 +1,27 @@
 import { Workflow, PluginManifest, ApiResponse } from './types';
+import { getApiBaseUrl, ensureDevPortResolved } from './runtimeEndpoints';
 
-// Use relative URLs in browser (proxied via Next.js rewrites)
-// Use full URL only for server-side or when explicitly set
-const API_BASE = typeof window !== 'undefined'
-  ? ''  // Browser: use relative URLs (proxied by Next.js)
-  : (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001');
+// Resolve the API base per request so the client follows the backend's actual
+// port. In dev mode the backend can auto-switch off 8001 (see runtimeEndpoints),
+// so we access it directly (backend CORS allows localhost:3000-3010) instead of
+// relying on Next.js rewrites, whose destination is fixed at dev-server startup.
+async function resolveApiBase(): Promise<string> {
+  if (typeof window !== 'undefined') {
+    await ensureDevPortResolved();
+    return getApiBaseUrl();
+  }
+  // Server-side (SSR): no rewrites available, use the configured URL.
+  return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001';
+}
 
 class ApiClient {
-  private baseUrl: string;
-
-  constructor(baseUrl: string) {
-    this.baseUrl = baseUrl;
-  }
-
   private async request<T>(
     endpoint: string,
     options: RequestInit = {}
   ): Promise<ApiResponse<T>> {
     try {
-      const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      const baseUrl = await resolveApiBase();
+      const response = await fetch(`${baseUrl}${endpoint}`, {
         ...options,
         headers: {
           'Content-Type': 'application/json',
@@ -161,7 +164,8 @@ class ApiClient {
       const formData = new FormData();
       formData.append('file', file);
 
-      const response = await fetch(`${this.baseUrl}/api/integrations/models/upload`, {
+      const baseUrl = await resolveApiBase();
+      const response = await fetch(`${baseUrl}/api/integrations/models/upload`, {
         method: 'POST',
         body: formData,
         // Don't set Content-Type header - browser will set it with boundary
@@ -195,7 +199,8 @@ class ApiClient {
       const formData = new FormData();
       formData.append('file', file);
 
-      const response = await fetch(`${this.baseUrl}/api/integrations/animations/upload`, {
+      const baseUrl = await resolveApiBase();
+      const response = await fetch(`${baseUrl}/api/integrations/animations/upload`, {
         method: 'POST',
         body: formData,
       });
@@ -365,5 +370,5 @@ export interface WorkflowMemory {
   updatedAt: string;
 }
 
-export const api = new ApiClient(API_BASE);
+export const api = new ApiClient();
 export default api;

--- a/apps/web/lib/runtimeEndpoints.ts
+++ b/apps/web/lib/runtimeEndpoints.ts
@@ -1,6 +1,81 @@
+/**
+ * Runtime resolution of the backend API / WebSocket base URL.
+ *
+ * In production / desktop mode the frontend is served from the backend's own
+ * origin, so `window.location.origin` is correct. In dev mode (Next.js on port
+ * 3000-3010) the backend runs separately on port 8001 — but it may auto-switch
+ * to 8002-8010 if 8001 is taken (see apps/server-ts/src/port.ts). We therefore
+ * probe /health across the range once per session and cache the live port.
+ *
+ * The synchronous getters (getApiBaseUrl/getWsBaseUrl) stay synchronous for the
+ * many existing call sites: they return the cached/last-known port, falling
+ * back to 8001 before resolution completes. Call `ensureDevPortResolved()` (a
+ * memoized, fire-once promise) at async entry points to guarantee the real port
+ * is known before the first request/connection.
+ */
+
+const DEFAULT_PORT = 8001;
+const MAX_PORT = 8010;
+const PROBE_TIMEOUT_MS = 800;
+const STORAGE_KEY = "aituber-flow-dev-port";
+
+export interface PortResolution {
+  /** The backend port currently in use. */
+  port: number;
+  /** The backend's default port (8001). */
+  defaultPort: number;
+  /** True when the backend is running on a non-default port. */
+  switched: boolean;
+}
+
+let cachedPort: number | null = null;
+let resolvePromise: Promise<PortResolution> | null = null;
+
 function isNextDevPort(port: string): boolean {
   const value = Number(port);
   return Number.isInteger(value) && value >= 3000 && value <= 3010;
+}
+
+/** True only in the browser while served from a Next.js dev port. */
+function inDevMode(): boolean {
+  try {
+    return typeof window !== "undefined" && !!window.location && isNextDevPort(window.location.port);
+  } catch {
+    return false;
+  }
+}
+
+function readSessionPort(): number | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const n = Number(raw);
+      if (Number.isInteger(n)) return n;
+    }
+  } catch {
+    // sessionStorage unavailable (SSR / privacy mode)
+  }
+  return null;
+}
+
+function storeResolvedPort(port: number): void {
+  cachedPort = port;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, String(port));
+  } catch {
+    // ignore
+  }
+}
+
+/** Best-known dev backend port right now (cache → sessionStorage → default). */
+function currentDevPort(): number {
+  if (cachedPort !== null) return cachedPort;
+  const stored = readSessionPort();
+  if (stored !== null) {
+    cachedPort = stored;
+    return stored;
+  }
+  return DEFAULT_PORT;
 }
 
 /**
@@ -14,26 +89,92 @@ export function getApiBaseUrl(): string {
   try {
     if (window && window.location) {
       if (isNextDevPort(window.location.port)) {
-        return "http://localhost:8001";
+        return `http://localhost:${currentDevPort()}`;
       }
       return window.location.origin;
     }
   } catch {
     // window not available during SSR/SSG
   }
-  return "http://localhost:8001";
+  return `http://localhost:${DEFAULT_PORT}`;
 }
 
 export function getWsBaseUrl(): string {
   try {
     if (window && window.location) {
       if (isNextDevPort(window.location.port)) {
-        return "ws://localhost:8001";
+        return `ws://localhost:${currentDevPort()}`;
       }
       return window.location.origin.replace(/^http/, "ws");
     }
   } catch {
     // window not available during SSR/SSG
   }
-  return "ws://localhost:8001";
+  return `ws://localhost:${DEFAULT_PORT}`;
+}
+
+async function probeHealth(port: number): Promise<PortResolution | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const res = await fetch(`http://localhost:${port}/health`, { signal: controller.signal });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { port?: number; defaultPort?: number };
+    const actualPort = typeof data.port === "number" ? data.port : port;
+    const defaultPort = typeof data.defaultPort === "number" ? data.defaultPort : DEFAULT_PORT;
+    return { port: actualPort, defaultPort, switched: actualPort !== defaultPort };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function resolveDevPort(): Promise<PortResolution> {
+  // Verify a previously cached port first (fast path for reloads).
+  const stored = readSessionPort();
+  if (stored !== null) {
+    const hit = await probeHealth(stored);
+    if (hit) {
+      storeResolvedPort(hit.port);
+      return hit;
+    }
+  }
+
+  for (let p = DEFAULT_PORT; p <= MAX_PORT; p++) {
+    const hit = await probeHealth(p);
+    if (hit) {
+      storeResolvedPort(hit.port);
+      return hit;
+    }
+  }
+
+  // Nothing responded (backend down). Fall back to default; do not cache so a
+  // later attempt can re-probe once the backend comes up.
+  return { port: DEFAULT_PORT, defaultPort: DEFAULT_PORT, switched: false };
+}
+
+/**
+ * Resolve the live backend port exactly once per page session. In production /
+ * desktop mode this is a no-op (resolves immediately with the default). Safe to
+ * call from many places — the underlying probe runs only once.
+ */
+export function ensureDevPortResolved(): Promise<PortResolution> {
+  if (!inDevMode()) {
+    return Promise.resolve({ port: DEFAULT_PORT, defaultPort: DEFAULT_PORT, switched: false });
+  }
+  if (!resolvePromise) {
+    resolvePromise = resolveDevPort();
+  }
+  return resolvePromise;
+}
+
+/**
+ * Synchronous snapshot of the resolution result for UI (e.g. the notification
+ * bar). Returns null until `ensureDevPortResolved()` has completed.
+ */
+export function getResolvedPortInfo(): PortResolution | null {
+  if (!inDevMode()) return null;
+  if (cachedPort === null) return null;
+  return { port: cachedPort, defaultPort: DEFAULT_PORT, switched: cachedPort !== DEFAULT_PORT };
 }

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -587,5 +587,8 @@
     "detailSettings": "Detail Settings",
     "openDetailSettings": "Open detail settings",
     "runFromNode": "Run from this node"
+  },
+  "portNotice": {
+    "message": "Port 8001 was in use, so the server started on port {port}"
   }
 }

--- a/apps/web/locales/ja.json
+++ b/apps/web/locales/ja.json
@@ -587,5 +587,8 @@
     "detailSettings": "詳細設定",
     "openDetailSettings": "詳細設定を開く",
     "runFromNode": "このノードから実行"
+  },
+  "portNotice": {
+    "message": "ポート 8001 が使用中だったため、ポート {port} で起動しました"
   }
 }

--- a/apps/web/stores/pluginStore.ts
+++ b/apps/web/stores/pluginStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { PluginManifest, CategoryDefinition, PluginCategory, ConfigField } from '@/lib/types';
-import { getApiBaseUrl } from '@/lib/runtimeEndpoints';
+import { getApiBaseUrl, ensureDevPortResolved } from '@/lib/runtimeEndpoints';
 
 // Default categories (fallback if API fails)
 const DEFAULT_CATEGORIES: CategoryDefinition[] = [
@@ -37,8 +37,6 @@ interface PluginState {
   getPluginConfig: (id: string) => Record<string, ConfigField> | undefined;
 }
 
-const API_BASE = getApiBaseUrl();
-
 export const usePluginStore = create<PluginState>((set, get) => ({
   plugins: [],
   categories: DEFAULT_CATEGORIES,
@@ -53,7 +51,8 @@ export const usePluginStore = create<PluginState>((set, get) => ({
     set({ isLoading: true, error: null });
 
     try {
-      const response = await fetch(`${API_BASE}/api/plugins`);
+      await ensureDevPortResolved();
+      const response = await fetch(`${getApiBaseUrl()}/api/plugins`);
       if (!response.ok) {
         throw new Error(`Failed to fetch plugins: ${response.status}`);
       }

--- a/tests/server/port.test.ts
+++ b/tests/server/port.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Port resolution tests (apps/server-ts/src/port.ts).
+ *
+ * Covers the auto-switch scan, the "explicit PORT never switches" contract,
+ * hot-reload reuse, and the /health payload shape. The port-scan logic takes an
+ * injectable probe so most tests run without binding real sockets; one
+ * integration test exercises the real Bun.serve probe against an occupied port.
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import {
+  findAvailablePort,
+  resolvePort,
+  healthPayload,
+  bunPortProbe,
+  DEFAULT_PORT,
+  MAX_PORT,
+  type PortProbe,
+} from "../../apps/server-ts/src/port";
+
+// A probe that treats the given set of ports as "in use".
+function probeExcept(occupied: Set<number>): PortProbe {
+  return (port) => !occupied.has(port);
+}
+
+describe("findAvailablePort", () => {
+  it("returns the first free port, skipping occupied ones", () => {
+    const probe = probeExcept(new Set([8001, 8002]));
+    expect(findAvailablePort(8001, 8010, "127.0.0.1", probe)).toBe(8003);
+  });
+
+  it("returns the start port when it is free", () => {
+    const probe = probeExcept(new Set());
+    expect(findAvailablePort(8001, 8010, "127.0.0.1", probe)).toBe(8001);
+  });
+
+  it("throws when the whole range is occupied", () => {
+    const all = new Set<number>();
+    for (let p = 8001; p <= 8010; p++) all.add(p);
+    const probe = probeExcept(all);
+    expect(() => findAvailablePort(8001, 8010, "127.0.0.1", probe)).toThrow(/No available port/);
+  });
+});
+
+describe("resolvePort", () => {
+  it("uses an explicit PORT verbatim and never scans", () => {
+    const probe: PortProbe = () => {
+      throw new Error("probe must not be called when PORT is explicit");
+    };
+    const result = resolvePort({ portEnv: "9000", hostname: "127.0.0.1", probe });
+    expect(result).toEqual({ port: 9000, defaultPort: 8001, switched: true, explicit: true });
+  });
+
+  it("treats an explicit default PORT as not switched", () => {
+    const probe: PortProbe = () => {
+      throw new Error("probe must not be called");
+    };
+    const result = resolvePort({ portEnv: "8001", hostname: "127.0.0.1", probe });
+    expect(result).toEqual({ port: 8001, defaultPort: 8001, switched: false, explicit: true });
+  });
+
+  it("scans for a free port when PORT is unset (default free)", () => {
+    const probe = probeExcept(new Set());
+    const result = resolvePort({ hostname: "127.0.0.1", probe });
+    expect(result).toEqual({ port: 8001, defaultPort: 8001, switched: false, explicit: false });
+  });
+
+  it("auto-switches to the next free port when 8001 is taken", () => {
+    const probe = probeExcept(new Set([8001]));
+    const result = resolvePort({ hostname: "127.0.0.1", probe });
+    expect(result).toEqual({ port: 8002, defaultPort: 8001, switched: true, explicit: false });
+  });
+
+  it("reuses the hot-reload port without probing", () => {
+    const probe: PortProbe = () => {
+      throw new Error("probe must not be called when reusePort is set");
+    };
+    const result = resolvePort({ reusePort: "8003", hostname: "127.0.0.1", probe });
+    expect(result).toEqual({ port: 8003, defaultPort: 8001, switched: true, explicit: false });
+  });
+
+  it("ignores an empty PORT string and scans instead", () => {
+    const probe = probeExcept(new Set([8001, 8002]));
+    const result = resolvePort({ portEnv: "", hostname: "127.0.0.1", probe });
+    expect(result.port).toBe(8003);
+    expect(result.explicit).toBe(false);
+  });
+});
+
+describe("healthPayload", () => {
+  it("includes the actual port and defaultPort", () => {
+    expect(healthPayload(8002)).toEqual({
+      status: "healthy",
+      version: "2.0.0",
+      runtime: "bun",
+      port: 8002,
+      defaultPort: 8001,
+    });
+  });
+
+  it("defaults defaultPort to 8001", () => {
+    expect(healthPayload(8001).defaultPort).toBe(DEFAULT_PORT);
+  });
+});
+
+describe("bunPortProbe (integration)", () => {
+  let occupied: ReturnType<typeof Bun.serve> | null = null;
+
+  afterEach(() => {
+    occupied?.stop(true);
+    occupied = null;
+  });
+
+  it("skips a genuinely occupied port and picks the next", () => {
+    // Occupy DEFAULT_PORT with a real server, then let the real probe scan.
+    occupied = Bun.serve({ port: DEFAULT_PORT, hostname: "127.0.0.1", fetch: () => new Response("x") });
+    const chosen = findAvailablePort(DEFAULT_PORT, MAX_PORT, "127.0.0.1", bunPortProbe);
+    expect(chosen).toBeGreaterThan(DEFAULT_PORT);
+    expect(chosen).toBeLessThanOrEqual(MAX_PORT);
+  });
+});


### PR DESCRIPTION
## 概要

closes #305

Web モード（`bun run dev`）でポート 8001 が使用中だと起動に失敗する問題への対応です。設計は issue #305 のコメント参照。デスクトップ（Tauri）は既に動的ポート予約があるため対象外。

**バックエンド（apps/server-ts）**
- `src/port.ts` 新設: `PORT` env 未指定時は 8001→8010 を順にスキャンし、最初に bind できたポートで起動（`Bun.serve` の `EADDRINUSE` を実測検証した probe 方式）。`PORT` 明示時は従来通り固定で自動切り替えなし
- `--hot` リロードで再スキャンしないよう、確定ポートを env に保存して再利用
- `/health` に `port`（実ポート）と `defaultPort`（8001）を追加

**フロントエンド（apps/web）**
- `lib/runtimeEndpoints.ts`: dev モード時に 8001→8010 の `/health` をプローブして実ポートを解決（セッション1回・memoized、sessionStorage キャッシュ＋再検証）
- REST は Next.js rewrites プロキシから解決済みポートへの直アクセスに変更（rewrites の宛先は dev サーバー起動時固定で動的ポートに追従できないため。CORS は既存の localhost:3000-3010 許可でカバー）
- WS 接続・プラグイン取得等の非同期入口で解決を await、モジュールスコープの URL 固定捕捉を遅延ゲッター化
- `components/ui/PortSwitchNotice.tsx` 新設: 8001 以外で起動していたら画面下部に通知バーを表示。× で閉じられ、閉じた状態はセッション中のみ記憶。i18n（日英）・ライト/ダークテーマ対応・アイコンレス

## テスト計画

- [x] `tests/server/port.test.ts` 追加（12 ケース）、`bun test tests/` 343 件全パス
- [x] typecheck（server-ts）/ `npm run build`（web）/ Biome（LF 展開で本物のみ確認）
- [x] 実機検証: 8001 を別プロセスで占有 → バックエンドが 8002 で起動、`/health` が `{"port":8002,"defaultPort":8001}` を返却
- [x] 実ブラウザ検証（Playwright）: `localhost:3000` で「ポート 8001 が使用中だったため、ポート 8002 で起動しました」の下部バー表示を確認、× クリックで消えることを確認
- [x] `PORT` 明示（占有中）→ 自動切り替えせず EADDRINUSE で失敗（設計通り）

## レビュー（Fable）

実装担当: Opus / レビュー: Fable（新体制の初運用）。設計逸脱なし、実装判断（rewrites 直アクセス化・同期ゲッター維持＋非同期入口 await）は妥当と判断。

既知の軽微な挙動:
- プローブ時、8001 を掴んでいるのが他アプリの HTTP サーバーだった場合、ブラウザコンソールに CORS エラーが 1 件出る（プローブは正しく次のポートへフォールバックするため実害なし。JSON 検証が必要なため no-cors 化は不可）
- dev モードかつ切替時のみオーバーレイページにもバーが出得るが、OBS 実運用（バックエンド origin 配信）では表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfvdGygZGLkMLvhQr1L6qp
